### PR TITLE
fix misspelling in eject console output

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -156,7 +156,7 @@ async function run () {
     const highlightVersion = tbPkgContents?.['dependencies']?.['highlight.js']
 
     if (!mineVersion || !uhtmlVersion || !highlightVersion) {
-      console.error('Unable to resolve ejected depdeency versions. Exiting...')
+      console.error('Unable to resolve ejected dependency versions. Exiting...')
       process.exit(1)
     }
 


### PR DESCRIPTION
Fixes the misspelling of `dependency` in the error output of the `domstack --eject` command.