### PR TITLE
Pass global.data.js output to template vars

### DIFF
--- a/lib/build-pages/index.js
+++ b/lib/build-pages/index.js
@@ -276,7 +276,7 @@ export async function buildPagesDirect (src, dest, siteData, _opts) {
         const buildResult = await templateBuilder({
           src,
           dest,
-          globalVars,
+          globalVars: { ...globalVars, ...globalDataVars },
           template,
           pages,
         })

--- a/lib/build-pages/index.js
+++ b/lib/build-pages/index.js
@@ -254,6 +254,9 @@ export async function buildPagesDirect (src, dest, siteData, _opts) {
     ? siteData.templates.filter(t => templateFilterSet.has(t.templateFile.filepath))
     : siteData.templates
 
+  // Merge once — globalVars and globalDataVars are constant for this build.
+  const templateGlobalVars = { ...globalVars, ...globalDataVars }
+
   await Promise.all([
     pMap(pagesToRender, async (page) => {
       try {
@@ -276,7 +279,7 @@ export async function buildPagesDirect (src, dest, siteData, _opts) {
         const buildResult = await templateBuilder({
           src,
           dest,
-          globalVars: { ...globalVars, ...globalDataVars },
+          globalVars: templateGlobalVars,
           template,
           pages,
         })

--- a/lib/build-pages/index.js
+++ b/lib/build-pages/index.js
@@ -277,7 +277,6 @@ export async function buildPagesDirect (src, dest, siteData, _opts) {
     pMap(templatesToRender, async (template) => {
       try {
         const buildResult = await templateBuilder({
-          src,
           dest,
           globalVars: templateGlobalVars,
           template,

--- a/lib/build-pages/page-builders/template-builder.js
+++ b/lib/build-pages/page-builders/template-builder.js
@@ -17,7 +17,7 @@ import { writeFile, mkdir } from 'fs/promises'
  * @template {Record<string, any>} T - The type of variables for the template
  * @callback TemplateFunction
  * @param {object} params - The parameters for the template.
- * @param {T} params.vars - All of the site globalVars.
+ * @param {T} params.vars - All of the site globalVars merged with global.data.js output.
  * @param {TemplateInfo} params.template - Info about the current template
  * @param {PageData<T, any, string>[]} params.pages - An array of info about every page
  * @returns {Promise<string | TemplateOutputOverride | TemplateOutputOverride[]>}
@@ -46,12 +46,13 @@ import { writeFile, mkdir } from 'fs/promises'
  */
 
 /**
- * The template builder renders templates agains the globalVars variables
+ * The template builder renders templates against the globalVars variables.
+ * globalVars passed here already includes global.data.js output merged in.
  * @template {Record<string, any>} T - The type of global variables for the template builder
  * @param {object}  params
  * @param  {string} params.src        - The src path of the site build.
  * @param  {string} params.dest       - The dest path of the site build.
- * @param  {T} params.globalVars - The resolvedGlobal vars object.
+ * @param  {T} params.globalVars - globalVars merged with global.data.js output.
  * @param  {TemplateInfo} params.template   - The TemplateInfo of the template.
  * @param  {PageData<T, any, string>[]} params.pages      - The array of PageData object.
  */

--- a/lib/build-pages/page-builders/template-builder.js
+++ b/lib/build-pages/page-builders/template-builder.js
@@ -50,7 +50,6 @@ import { writeFile, mkdir } from 'fs/promises'
  * globalVars passed here already includes global.data.js output merged in.
  * @template {Record<string, any>} T - The type of global variables for the template builder
  * @param {object}  params
- * @param  {string} params.src        - The src path of the site build.
  * @param  {string} params.dest       - The dest path of the site build.
  * @param  {T} params.globalVars - globalVars merged with global.data.js output.
  * @param  {TemplateInfo} params.template   - The TemplateInfo of the template.

--- a/lib/build-pages/page-data.js
+++ b/lib/build-pages/page-data.js
@@ -168,7 +168,6 @@ export class PageData {
     const { pageVars, type } = pageInfo
     this.pageVars = await resolveVars({
       varsPath: pageVars?.filepath,
-      resolveVars: globalVars,
     })
     await resolvePostVars({ varsPath: pageVars?.filepath }) // throws if postVars export is detected
 

--- a/lib/build-pages/resolve-vars.js
+++ b/lib/build-pages/resolve-vars.js
@@ -3,7 +3,6 @@
  *
  * @param {object} params
  * @param {string} [params.varsPath] - Path to the file containing the variables.
- * @param {object} [params.resolveVars] - Any variables you want passed to the resolveFunction.
  * @param {string} [params.key='default'] - The key to extract from the imported module. Default: 'default'
  * @returns {Promise<object>} - Returns the resolved variables. If the imported variable is a function, it executes and returns its result. Otherwise, it returns the variable directly.
  */

--- a/test-cases/general-features/index.test.js
+++ b/test-cases/general-features/index.test.js
@@ -103,6 +103,21 @@ test.describe('general-features', () => {
     const jsChunkFiles = files.filter(f => f.relname.match(/chunks\/js\/chunk-.+\.js$/))
     assert.ok(jsChunkFiles.length > 0, 'at least one shared JS chunk was produced with a hashed name')
 
+    // Verify that global.data.js output reaches template vars
+    const feedJsonPath = path.join(dest, 'feeds/feed.json')
+    try {
+      const feedContent = await readFile(feedJsonPath, 'utf8')
+      const feedData = JSON.parse(feedContent)
+      assert.strictEqual(
+        feedData._globalDataSentinel,
+        'data-from-global-dot-data',
+        'feeds template received globalDataSentinel from global.data.js via vars'
+      )
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error('Unknown error', { cause: err })
+      assert.fail('Failed to verify global.data.js output in template vars: ' + error.message)
+    }
+
     // Special test for global.data.js blogPostsHtml
     const indexPath = path.join(dest, 'index.html')
     try {

--- a/test-cases/general-features/src/feeds.template.js
+++ b/test-cases/general-features/src/feeds.template.js
@@ -12,7 +12,8 @@ import jsonfeedToAtom from 'jsonfeed-to-atom'
  *  authorUrl: string,
  *  authorImgUrl: string,
  *  publishDate: string,
- *  siteDescription: string
+ *  siteDescription: string,
+ *  globalDataSentinel: string,
  * }>}
  */
 export default async function * feedsTemplate ({
@@ -23,6 +24,7 @@ export default async function * feedsTemplate ({
     authorUrl,
     authorImgUrl,
     siteDescription,
+    globalDataSentinel,
   },
   pages,
 }) {
@@ -39,6 +41,7 @@ export default async function * feedsTemplate ({
     home_page_url: homePageUrl,
     feed_url: `${homePageUrl}/feed.json`,
     description: siteDescription,
+    _globalDataSentinel: globalDataSentinel,
     author: {
       name: authorName,
       url: authorUrl,

--- a/test-cases/general-features/src/global.data.js
+++ b/test-cases/general-features/src/global.data.js
@@ -5,7 +5,7 @@
 import { html } from 'htm/preact'
 import { render } from 'preact-render-to-string'
 
-/** @type {AsyncGlobalDataFunction<{ blogPostsHtml: string }>} */
+/** @type {AsyncGlobalDataFunction<{ blogPostsHtml: string, globalDataSentinel: string }>} */
 export default async function ({ pages }) {
   const blogPosts = pages
     .filter(page => page.vars?.layout === 'blog' && page.vars?.publishDate)
@@ -36,5 +36,5 @@ export default async function ({ pages }) {
     </ul>
   `)
 
-  return { blogPostsHtml }
+  return { blogPostsHtml, globalDataSentinel: 'data-from-global-dot-data' }
 }


### PR DESCRIPTION
Closes #235

Templates received only `global.vars.js` output in `vars`, while pages received both `global.vars.js` and `global.data.js` output via the `PageData.vars` getter. This inconsistency forced every template that needed aggregated data to re-derive it from the `pages` array, duplicating logic that `global.data.js` already performs.

The fix merges `globalDataVars` into the `globalVars` object passed to `templateBuilder`, making template `vars` consistent with how page `vars` already work.

Before this change, a feeds template that needed aggregated post data had to re-implement the full filtering and sorting pipeline from `global.data.js`. After this change it can read `vars.recentPosts` (or whatever `global.data.js` returns) directly.

The merge order follows the same precedence as `PageData.vars`: `globalVars` is the base, and `globalDataVars` overrides it. Templates that do not have a `global.data.js` file are unaffected since `globalDataVars` will be an empty object in that case.