### PR TITLE
Export PageData, PageInfo, and param types from the package entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -1232,6 +1232,7 @@ You can use `domstack`'s built-in types to strongly type your layout, page, and 
 
 ```ts
 import type {
+  // Function types
   LayoutFunction,
   AsyncLayoutFunction,
   GlobalDataFunction,
@@ -1239,13 +1240,34 @@ import type {
   PageFunction,
   AsyncPageFunction,
   TemplateFunction,
-  TemplateAsyncIterator
+  TemplateAsyncIterator,
+  // Data/param types
+  PageData,
+  PageInfo,
+  TemplateInfo,
+  LayoutFunctionParams,
+  GlobalDataFunctionParams,
+  PageFunctionParams,
+  TemplateFunctionParams,
 } from '@domstack/static'
 ```
 
 > **Note:** All function types have both synchronous and asynchronous variants (e.g., `LayoutFunction` and `AsyncLayoutFunction`). Use the async variants when your function is an `async` function.
 
 They are all generic and accept a variable template that you can develop and share between files.
+
+The data and param types (`PageData`, `PageInfo`, `TemplateInfo`, `*FunctionParams`) are useful when you want to annotate variables or helper functions that receive these objects without using the function types directly:
+
+```ts
+import type { GlobalDataFunctionParams, PageData, PageInfo } from '@domstack/static'
+
+function getPublishedPages({ pages }: GlobalDataFunctionParams): PageData[] {
+  return pages.filter((p: PageData) => {
+    const info: PageInfo = p.pageInfo
+    return !info.draft
+  })
+}
+```
 
 #### Advanced Type Parameters for PageFunction and LayoutFunction
 

--- a/index.js
+++ b/index.js
@@ -2,12 +2,12 @@
  * @import { DomStackOpts as DomStackOpts, Results, SiteData } from './lib/builder.js'
  * @import { Stats } from 'node:fs'
  * @import { FSWatcher } from 'chokidar'
- * @import { AsyncLayoutFunction, LayoutFunction } from './lib/build-pages/page-data.js'
- * @import { PageFunction, AsyncPageFunction } from './lib/build-pages/page-builders/page-writer.js'
- * @import { TemplateFunction } from './lib/build-pages/page-builders/template-builder.js'
+ * @import { AsyncLayoutFunction, LayoutFunction, LayoutFunctionParams } from './lib/build-pages/page-data.js'
+ * @import { PageFunction, AsyncPageFunction, PageFunctionParams } from './lib/build-pages/page-builders/page-writer.js'
+ * @import { TemplateFunction, TemplateFunctionParams } from './lib/build-pages/page-builders/template-builder.js'
  * @import { TemplateAsyncIterator } from './lib/build-pages/page-builders/template-builder.js'
  * @import { TemplateOutputOverride } from './lib/build-pages/page-builders/template-builder.js'
- * @import { GlobalDataFunction, AsyncGlobalDataFunction, WorkerBuildStepResult } from './lib/build-pages/index.js'
+ * @import { GlobalDataFunction, AsyncGlobalDataFunction, WorkerBuildStepResult, GlobalDataFunctionParams } from './lib/build-pages/index.js'
  * @import { BuildOptions, BuildContext } from 'esbuild'
  * @import { PageInfo, TemplateInfo } from './lib/identify-pages.js'
 */
@@ -48,6 +48,8 @@ import {
 import { resolveVars } from './lib/build-pages/resolve-vars.js'
 import { ensureDest } from './lib/helpers/ensure-dest.js'
 import { DomStackAggregateError } from './lib/helpers/domstack-aggregate-error.js'
+
+export { PageData } from './lib/build-pages/page-data.js'
 
 /**
  * @typedef {BuildOptions} BuildOptions
@@ -101,6 +103,36 @@ import { DomStackAggregateError } from './lib/helpers/domstack-aggregate-error.j
 
 /**
  * @typedef {TemplateOutputOverride} TemplateOutputOverride
+ */
+
+/**
+ * @typedef {PageInfo} PageInfo
+ */
+
+/**
+ * @typedef {TemplateInfo} TemplateInfo
+ */
+
+/**
+ * @template {Record<string, any>} T - The type of variables passed to the layout function
+ * @template [U=any] U - The return type of the page function
+ * @template [V=string] V - The return type of the layout function
+ * @typedef {LayoutFunctionParams<T, U, V>} LayoutFunctionParams
+ */
+
+/**
+ * @typedef {GlobalDataFunctionParams} GlobalDataFunctionParams
+ */
+
+/**
+ * @template {Record<string, any>} T - The type of variables passed to the page function
+ * @template [U=any] U - The return type of the page function
+ * @typedef {PageFunctionParams<T, U>} PageFunctionParams
+ */
+
+/**
+ * @template {Record<string, any>} T - The type of variables for the template function
+ * @typedef {TemplateFunctionParams<T>} TemplateFunctionParams
  */
 
 const DEFAULT_IGNORES = /** @type {const} */ ([

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@
  * @import { TemplateFunction } from './lib/build-pages/page-builders/template-builder.js'
  * @import { TemplateAsyncIterator } from './lib/build-pages/page-builders/template-builder.js'
  * @import { TemplateOutputOverride } from './lib/build-pages/page-builders/template-builder.js'
+ * @import { TemplateFunctionParams } from './lib/build-pages/page-builders/template-builder.js'
  * @import { GlobalDataFunction, AsyncGlobalDataFunction, WorkerBuildStepResult, GlobalDataFunctionParams } from './lib/build-pages/index.js'
  * @import { BuildOptions, BuildContext } from 'esbuild'
  * @import { PageInfo, TemplateInfo } from './lib/identify-pages.js'
@@ -130,6 +131,10 @@ export { PageData } from './lib/build-pages/page-data.js'
  * @typedef {PageFunctionParams<T, U>} PageFunctionParams
  */
 
+/**
+ * @template {Record<string, any>} [T=Record<string, any>] - The type of variables for the template function
+ * @typedef {TemplateFunctionParams<T>} TemplateFunctionParams
+ */
 
 const DEFAULT_IGNORES = /** @type {const} */ ([
   '.*',

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
  * @import { FSWatcher } from 'chokidar'
  * @import { AsyncLayoutFunction, LayoutFunction, LayoutFunctionParams } from './lib/build-pages/page-data.js'
  * @import { PageFunction, AsyncPageFunction, PageFunctionParams } from './lib/build-pages/page-builders/page-writer.js'
- * @import { TemplateFunction, TemplateFunctionParams } from './lib/build-pages/page-builders/template-builder.js'
+ * @import { TemplateFunction } from './lib/build-pages/page-builders/template-builder.js'
  * @import { TemplateAsyncIterator } from './lib/build-pages/page-builders/template-builder.js'
  * @import { TemplateOutputOverride } from './lib/build-pages/page-builders/template-builder.js'
  * @import { GlobalDataFunction, AsyncGlobalDataFunction, WorkerBuildStepResult, GlobalDataFunctionParams } from './lib/build-pages/index.js'
@@ -130,10 +130,6 @@ export { PageData } from './lib/build-pages/page-data.js'
  * @typedef {PageFunctionParams<T, U>} PageFunctionParams
  */
 
-/**
- * @template {Record<string, any>} T - The type of variables for the template function
- * @typedef {TemplateFunctionParams<T>} TemplateFunctionParams
- */
 
 const DEFAULT_IGNORES = /** @type {const} */ ([
   '.*',

--- a/index.js
+++ b/index.js
@@ -115,10 +115,10 @@ export { PageData } from './lib/build-pages/page-data.js'
  */
 
 /**
- * @template {Record<string, any>} T - The type of variables passed to the layout function
- * @template [U=any] U - The return type of the page function
- * @template [V=string] V - The return type of the layout function
- * @typedef {LayoutFunctionParams<T, U, V>} LayoutFunctionParams
+ * @template {Record<string, any>} Vars - The type of variables passed to the layout function
+ * @template [PageReturn=any] PageReturn - The return type of the page function
+ * @template [LayoutReturn=string] LayoutReturn - The return type of the layout function
+ * @typedef {LayoutFunctionParams<Vars, PageReturn, LayoutReturn>} LayoutFunctionParams
  */
 
 /**
@@ -126,14 +126,14 @@ export { PageData } from './lib/build-pages/page-data.js'
  */
 
 /**
- * @template {Record<string, any>} T - The type of variables passed to the page function
- * @template [U=any] U - The return type of the page function
- * @typedef {PageFunctionParams<T, U>} PageFunctionParams
+ * @template {Record<string, any>} Vars - The type of variables passed to the page function
+ * @template [PageReturn=any] PageReturn - The return type of the page function
+ * @typedef {PageFunctionParams<Vars, PageReturn>} PageFunctionParams
  */
 
 /**
- * @template {Record<string, any>} [T=Record<string, any>] - The type of variables for the template function
- * @typedef {TemplateFunctionParams<T>} TemplateFunctionParams
+ * @template {Record<string, any>} [Vars=Record<string, any>] - The type of variables for the template function
+ * @typedef {TemplateFunctionParams<Vars>} TemplateFunctionParams
  */
 
 const DEFAULT_IGNORES = /** @type {const} */ ([

--- a/lib/build-pages/index.js
+++ b/lib/build-pages/index.js
@@ -1,7 +1,7 @@
 /**
  * @import { BuilderOptions } from './page-builders/page-writer.js'
  * @import { BuildStep, SiteData, DomStackOpts } from '../builder.js'
- * @import { InternalLayoutFunction } from './page-data.js'
+ * @import { ResolvedLayout } from './page-data.js'
  */
 
 import { Worker } from 'worker_threads'
@@ -60,17 +60,6 @@ const __dirname = import.meta.dirname
 
 /**
  * @typedef {Awaited<ReturnType<PageBuildStep>>} PageBuildStepResult
- */
-
-/**
- * @template {Record<string, any>} T - The type of variables for the layout
- * @template [U=any] U - The return type of the page function (defaults to any)
- * @template [V=string] V - The return type of the layout function (defaults to string)
- * @typedef ResolvedLayout
- * @property {InternalLayoutFunction<T, U, V>} render - The layout function
- * @property {string} name - The name of the layout
- * @property {string | null} layoutStylePath - The string path to the layout style
- * @property {string | null} layoutClientPath - The string path to the layout client
  */
 
 /**

--- a/lib/build-pages/page-builders/template-builder.js
+++ b/lib/build-pages/page-builders/template-builder.js
@@ -25,15 +25,10 @@ import { writeFile, mkdir } from 'fs/promises'
  */
 
 /**
- * @template {Record<string, any>} T - The type of variables for the template function parameters
- * @typedef {Parameters<TemplateFunction<T>>} TemplateFunctionParams
-*/
-
-/**
  * Callback for rendering a template with an async iterator.
  * @template T - The type of variables for the template async iterator
  * @callback TemplateAsyncIterator
- * @param {TemplateFunctionParams<T>[0]} params - Parameters of the template function.
+ * @param {Parameters<TemplateFunction<T>>[0]} params - Parameters of the template function.
  * @returns {AsyncIterable<TemplateOutputOverride>}
  */
 

--- a/lib/build-pages/page-builders/template-builder.js
+++ b/lib/build-pages/page-builders/template-builder.js
@@ -38,7 +38,7 @@ import { writeFile, mkdir } from 'fs/promises'
  * Callback for rendering a template with an async iterator.
  * @template T - The type of variables for the template async iterator
  * @callback TemplateAsyncIterator
- * @param {Parameters<TemplateFunction<T>>[0]} params - Parameters of the template function.
+ * @param {TemplateFunctionParams<T>} params - Parameters of the template function.
  * @returns {AsyncIterable<TemplateOutputOverride>}
  */
 

--- a/lib/build-pages/page-builders/template-builder.js
+++ b/lib/build-pages/page-builders/template-builder.js
@@ -12,6 +12,16 @@ import { writeFile, mkdir } from 'fs/promises'
  * }} TemplateOutputOverride */
 
 /**
+ * The parameters object passed to a {@link TemplateFunction} or {@link TemplateAsyncIterator}.
+ *
+ * @template {Record<string, any>} [T=Record<string, any>] - The type of variables for the template
+ * @typedef {object} TemplateFunctionParams
+ * @property {T} vars - All of the site globalVars.
+ * @property {TemplateInfo} template - Info about the current template.
+ * @property {PageData<T, any, string>[]} pages - An array of info about every page.
+ */
+
+/**
  * Callback for rendering a template.
  *
  * @template {Record<string, any>} T - The type of variables for the template

--- a/lib/build-pages/page-data.js
+++ b/lib/build-pages/page-data.js
@@ -1,7 +1,6 @@
 /**
  * @import { PageInfo } from '../identify-pages.js'
  * @import { BuilderOptions } from './page-builders/page-writer.js'
- * @import { ResolvedLayout } from './index.js'
  */
 
 import { resolveVars, resolvePostVars } from './resolve-vars.js'
@@ -75,6 +74,19 @@ export async function resolveLayout (layoutPath) {
   * @template [V=string] V - The return type of the layout function (defaults to string)
   * @typedef {LayoutFunction<T, U, V> | AsyncLayoutFunction<T, U, V>} InternalLayoutFunction
   */
+
+/**
+ * A resolved layout module with its render function and associated asset paths.
+ *
+ * @template {Record<string, any>} T - The type of variables for the layout
+ * @template [U=any] U - The return type of the page function (defaults to any)
+ * @template [V=string] V - The return type of the layout function (defaults to string)
+ * @typedef ResolvedLayout
+ * @property {InternalLayoutFunction<T, U, V>} render - The layout function
+ * @property {string} name - The name of the layout
+ * @property {string | null} layoutStylePath - The string path to the layout style
+ * @property {string | null} layoutClientPath - The string path to the layout client
+ */
 
 /**
  * Represents the data for a page.

--- a/test-cases/type-exports/index.test.js
+++ b/test-cases/type-exports/index.test.js
@@ -5,13 +5,13 @@ import { PageData } from '../../index.js'
 
 /**
  * Smoke test that all public types are importable from the package entry point.
- * The @typedef imports below are verified by TypeScript at compile time via `npm run test:tsc`.
+ * The type imports below are verified by TypeScript at compile time via `npm run test:tsc`.
  *
  * @typedef {import('../../index.js').PageInfo} PageInfo
  * @typedef {import('../../index.js').TemplateInfo} TemplateInfo
- * @typedef {import('../../index.js').LayoutFunctionParams} LayoutFunctionParams
+ * @typedef {import('../../index.js').LayoutFunctionParams<any>} LayoutFunctionParams
  * @typedef {import('../../index.js').GlobalDataFunctionParams} GlobalDataFunctionParams
- * @typedef {import('../../index.js').PageFunctionParams} PageFunctionParams
+ * @typedef {import('../../index.js').PageFunctionParams<any>} PageFunctionParams
  * @typedef {import('../../index.js').TemplateFunctionParams} TemplateFunctionParams
  */
 

--- a/test-cases/type-exports/index.test.js
+++ b/test-cases/type-exports/index.test.js
@@ -1,0 +1,20 @@
+// @ts-check
+import { test } from 'node:test'
+import assert from 'node:assert'
+import { PageData } from '../../index.js'
+
+/**
+ * Smoke test that all public types are importable from the package entry point.
+ * The @typedef imports below are verified by TypeScript at compile time via `npm run test:tsc`.
+ *
+ * @typedef {import('../../index.js').PageInfo} PageInfo
+ * @typedef {import('../../index.js').TemplateInfo} TemplateInfo
+ * @typedef {import('../../index.js').LayoutFunctionParams} LayoutFunctionParams
+ * @typedef {import('../../index.js').GlobalDataFunctionParams} GlobalDataFunctionParams
+ * @typedef {import('../../index.js').PageFunctionParams} PageFunctionParams
+ * @typedef {import('../../index.js').TemplateFunctionParams} TemplateFunctionParams
+ */
+
+test('PageData is importable from the package entry point', () => {
+  assert.strictEqual(typeof PageData, 'function', 'PageData is a class')
+})


### PR DESCRIPTION
Closes #227

The package exported function types (`LayoutFunction`, `PageFunction`, `TemplateFunction`, etc.) but not the data types those functions receive. Users writing layouts, templates, `global.data.js`, or page functions had no first-class way to import `PageData`, `PageInfo`, or any of the param types. The only options were reaching into internal module paths (fragile) or writing partial inline JSDoc annotations by hand.

This change adds:

- `PageData` as a runtime re-export from the package entry point (useful for `instanceof` checks as well as typing)
- `PageInfo` and `TemplateInfo` as typedef re-exports
- `LayoutFunctionParams`, `GlobalDataFunctionParams`, `PageFunctionParams`, and `TemplateFunctionParams` as typedef re-exports

All types were already defined in internal source files. This just makes them importable from `@domstack/static` directly.

After this change, JSDoc users can write:

```js
/** @type {import('@domstack/static').GlobalDataFunction} */
export default function globalData ({ pages }) {
  // pages[0].pageInfo.path  -- autocompletes
}
```

And TypeScript users can write:

```ts
import type { PageData, PageInfo, LayoutFunctionParams } from '@domstack/static'
```

No breaking changes. All existing exports remain unchanged.