### PR TITLE
Cache page vars and add markdown content helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1082,9 +1082,9 @@ const posts = pages.filter(p => {
 })
 ```
 
-**Raw markdown source is not exposed as `page.vars.content` by default.** For markdown pages, `page.vars` contains front matter-derived values such as `title`, but does not automatically include the raw markdown body as `content`. If you need the raw source, read it from `page.pageInfo.pageFile.filepath`. To get rendered HTML, call `page.renderInnerPage({ pages })`.
+**Raw markdown source is not exposed as `page.vars.content` by default.** For markdown pages, `page.vars` contains front matter-derived values such as `title`, but does not automatically include the raw markdown body as `content`. If you need the raw source, use `page.pageInfo.pageFile.filepath` to locate the source file on disk and read that file. To get rendered HTML, call `page.renderInnerPage({ pages })`.
 
-**`renderInnerPage()` is available.** `global.data.js` receives fully initialized `PageData` instances, so you can call `renderInnerPage()` here. See [Accessing rendered page content](#accessing-rendered-page-content) for usage and performance guidance.
+**`renderInnerPage()` is available.** `global.data.js` runs after page initialization has been attempted, and receives `PageData` instances (some may be uninitialized if they failed to initialize), so you can call `renderInnerPage()` here with the same care described above for `page.vars` and other page-dependent access.
 
 ### `esbuild.settings.ts`
 

--- a/README.md
+++ b/README.md
@@ -1069,19 +1069,20 @@ const date = page.vars.date
 
 For large sites with hundreds of pages, caching the result once per page reduces build time noticeably.
 
-**`page.vars` can throw.** If a page vars module has a syntax error, a missing dependency, or a runtime error, accessing `.vars` will throw. Wrap accesses in `try/catch` when iterating all pages so one broken page does not abort the whole function:
+**`page.vars` can throw.** If a page failed to initialize (often due to page vars module syntax errors, missing dependencies, or runtime errors), accessing `.vars` will throw. Wrap accesses in `try/catch` when iterating all pages so one broken page does not abort the whole function:
 
 ```js
 const posts = pages.filter(p => {
   try {
-    return p.vars.layout === 'article' && p.vars.date
+    const vars = p.vars
+    return vars.layout === 'article' && vars.date
   } catch {
     return false
   }
 })
 ```
 
-**`page.vars.content` is raw source, not rendered HTML.** For markdown pages, `vars.content` is the raw markdown string read from the file. To get rendered HTML, call `page.renderInnerPage({ pages })`.
+**Raw markdown source is not exposed as `page.vars.content` by default.** For markdown pages, `page.vars` contains front matter-derived values such as `title`, but does not automatically include the raw markdown body as `content`. If you need the raw source, read it from `page.pageInfo.pageFile.filepath`. To get rendered HTML, call `page.renderInnerPage({ pages })`.
 
 **`renderInnerPage()` is available.** `global.data.js` receives fully initialized `PageData` instances, so you can call `renderInnerPage()` here. See [Accessing rendered page content](#accessing-rendered-page-content) for usage and performance guidance.
 

--- a/README.md
+++ b/README.md
@@ -1053,6 +1053,38 @@ The returned object is stamped onto every page's vars before rendering, so any p
 
 Use `GlobalDataFunction<T>` or `AsyncGlobalDataFunction<T>` to type the function where `T` is the shape of the object you return.
 
+**Caveats:**
+
+**`page.vars` is a computed getter.** Each access performs a fresh merge of all variable sources. Cache the result when reading multiple properties from the same page:
+
+```js
+// good: one merge per page
+const vars = page.vars
+const { title, date } = vars
+
+// avoid: merges on every property access
+const title = page.vars.title
+const date = page.vars.date
+```
+
+For large sites with hundreds of pages, caching the result once per page reduces build time noticeably.
+
+**`page.vars` can throw.** If a page vars module has a syntax error, a missing dependency, or a runtime error, accessing `.vars` will throw. Wrap accesses in `try/catch` when iterating all pages so one broken page does not abort the whole function:
+
+```js
+const posts = pages.filter(p => {
+  try {
+    return p.vars.layout === 'article' && p.vars.date
+  } catch {
+    return false
+  }
+})
+```
+
+**`page.vars.content` is raw source, not rendered HTML.** For markdown pages, `vars.content` is the raw markdown string read from the file. To get rendered HTML, call `page.renderInnerPage({ pages })`.
+
+**`renderInnerPage()` is available.** `global.data.js` receives fully initialized `PageData` instances, so you can call `renderInnerPage()` here. See [Accessing rendered page content](#accessing-rendered-page-content) for usage and performance guidance.
+
 ### `esbuild.settings.ts`
 
 This is an optional file you can create anywhere.

--- a/README.md
+++ b/README.md
@@ -1055,36 +1055,31 @@ Use `GlobalDataFunction<T>` or `AsyncGlobalDataFunction<T>` to type the function
 
 **Caveats:**
 
-**`page.vars` is a computed getter.** Each access performs a fresh merge of all variable sources. Cache the result when reading multiple properties from the same page:
+**`page.vars` is a cached, read-only computed getter.** The first access merges all variable sources and DomStack caches a shallow-frozen result. Direct access and destructuring are both fine. Treat the returned object as read-only; if you need derived values, create a new object instead of mutating `page.vars`.
+
+**`page.vars` can throw.** If a page failed to initialize (often due to page vars module syntax errors, missing dependencies, or runtime errors), accessing `.vars` will throw. Treat this as a build issue to fix.
+
+**Raw markdown source is not exposed as `page.vars.content` by default.** For markdown pages, `page.vars` contains front matter-derived values such as `title`, but does not automatically include the raw markdown body as `content`. If you need the raw markdown body, call `await page.readMarkdownContent()`. To get rendered HTML, call `page.renderInnerPage({ pages })`.
+
+**`renderInnerPage()` is available.** `global.data.js` runs after page initialization has been attempted, and receives `PageData` instances (some may be uninitialized if they failed to initialize), so you can call `renderInnerPage()` here with the same care described above for `page.vars` and other page-dependent access. It renders the page body without its layout.
 
 ```js
-// good: one merge per page
-const vars = page.vars
-const { title, date } = vars
+import pMap from 'p-map'
 
-// avoid: merges on every property access
-const title = page.vars.title
-const date = page.vars.date
+export default async function globalData ({ pages }) {
+  const posts = pages
+    .filter(page => page.vars.layout === 'blog')
+    .sort((a, b) => new Date(b.vars.publishDate) - new Date(a.vars.publishDate))
+
+  const renderedPosts = await pMap(posts, async page => ({
+    title: page.vars.title,
+    url: page.pageInfo.url,
+    html: await page.renderInnerPage({ pages }),
+  }), { concurrency: 4 })
+
+  return { renderedPosts }
+}
 ```
-
-For large sites with hundreds of pages, caching the result once per page reduces build time noticeably.
-
-**`page.vars` can throw.** If a page failed to initialize (often due to page vars module syntax errors, missing dependencies, or runtime errors), accessing `.vars` will throw. Wrap accesses in `try/catch` when iterating all pages so one broken page does not abort the whole function:
-
-```js
-const posts = pages.filter(p => {
-  try {
-    const vars = p.vars
-    return vars.layout === 'article' && vars.date
-  } catch {
-    return false
-  }
-})
-```
-
-**Raw markdown source is not exposed as `page.vars.content` by default.** For markdown pages, `page.vars` contains front matter-derived values such as `title`, but does not automatically include the raw markdown body as `content`. If you need the raw source, read it from `page.pageInfo.pageFile.filepath`. To get rendered HTML, call `page.renderInnerPage({ pages })`.
-
-**`renderInnerPage()` is available.** `global.data.js` receives fully initialized `PageData` instances, so you can call `renderInnerPage()` here. See [Accessing rendered page content](#accessing-rendered-page-content) for usage and performance guidance.
 
 ### `esbuild.settings.ts`
 

--- a/lib/build-pages/page-builders/md/index.js
+++ b/lib/build-pages/page-builders/md/index.js
@@ -7,6 +7,7 @@ import { readFile } from 'fs/promises'
 import yaml from 'js-yaml'
 import { getMd, renderMd } from './get-md.js'
 import { extractFirstH1 } from './extract-title-from-md.js'
+import { parseMdFileContents } from './parse-md.js'
 
 /** @type {markdownIt | null} */
 let md = null
@@ -24,19 +25,10 @@ export async function mdBuilder ({ pageInfo, options }) {
   if (!md) md = await getMd(markdownItSettingsPath)
   const fileContents = await readFile(pageInfo.pageFile.filepath, 'utf8')
 
-  /** @type {object} */
-  let frontMatter
-  /** @type {string} */
-  let mdUnparsed
-  if (fileContents.trim().startsWith('---')) {
-    const [/* _ */, frontMatterUnparsed, ...mdParts] = fileContents.split('---')
-    mdUnparsed = mdParts.join('---')
-    // @ts-ignore
-    frontMatter = yaml.load(frontMatterUnparsed ?? '')
-  } else {
-    frontMatter = {}
-    mdUnparsed = fileContents
-  }
+  const { frontMatterUnparsed, markdownContent: mdUnparsed } = parseMdFileContents(fileContents)
+  const frontMatter = frontMatterUnparsed === null
+    ? {}
+    : yaml.load(frontMatterUnparsed)
 
   // Extract title from first H1 using markdown-it's token API
   const title = extractFirstH1(mdUnparsed)

--- a/lib/build-pages/page-builders/md/parse-md.js
+++ b/lib/build-pages/page-builders/md/parse-md.js
@@ -1,0 +1,21 @@
+/**
+ * Split markdown file contents into front matter and markdown content.
+ *
+ * @param {string} fileContents
+ * @returns {{ frontMatterUnparsed: string | null, markdownContent: string }}
+ */
+export function parseMdFileContents (fileContents) {
+  if (!fileContents.trim().startsWith('---')) {
+    return {
+      frontMatterUnparsed: null,
+      markdownContent: fileContents,
+    }
+  }
+
+  const [/* _ */, frontMatterUnparsed, ...mdParts] = fileContents.split('---')
+
+  return {
+    frontMatterUnparsed: frontMatterUnparsed ?? '',
+    markdownContent: mdParts.join('---'),
+  }
+}

--- a/lib/build-pages/page-data.js
+++ b/lib/build-pages/page-data.js
@@ -3,8 +3,10 @@
  * @import { BuilderOptions } from './page-builders/page-writer.js'
  */
 
+import { readFile } from 'node:fs/promises'
 import { resolveVars, resolvePostVars } from './resolve-vars.js'
 import { pageBuilders } from './page-builders/index.js'
+import { parseMdFileContents } from './page-builders/md/parse-md.js'
 import pretty from 'pretty'
 
 /**
@@ -104,6 +106,8 @@ export class PageData {
   /** @type {string[]} */ scripts = []
   /** @type {WorkerFiles} */ workerFiles = {}
   /** @type {boolean} */ #initialized = false
+  /** @type {T | null} */ #varsCache = null
+  /** @type {[object, object, object | null, object | null] | null} */ #varsCacheSources = null
   /** @type {string?} */ #defaultStyle = null
   /** @type {string?} */ #defaultClient = null
   /** @type {BuilderOptions} */ builderOptions
@@ -144,19 +148,36 @@ export class PageData {
   }
 
   /**
-   * Returns the fully resolved variable set for the page. Requires initialization.
+   * Returns the cached, shallow-frozen variable set for the page. Requires initialization.
    * @return {T} globalVars, pageVars, and buildVars merged together
    */
   get vars () {
     if (!this.#initialized) throw new Error(`Initialize PageData before accessing vars for page "${this.pageInfo?.path ?? '<unknown page>'}"`)
+    const sources = /** @type {[object, object, object | null, object | null]} */ ([
+      this.globalVars,
+      this.globalDataVars,
+      this.pageVars,
+      this.builderVars,
+    ])
+
+    if (
+      this.#varsCache &&
+      this.#varsCacheSources &&
+      this.#varsCacheSources.every((source, index) => source === sources[index])
+    ) {
+      return this.#varsCache
+    }
+
     try {
       const { globalVars, globalDataVars, pageVars, builderVars } = this
-      return /** @type {T} */ (/** @type {unknown} */ ({
+      this.#varsCache = /** @type {T} */ (/** @type {unknown} */ (Object.freeze({
         ...globalVars,
         ...globalDataVars,
         ...pageVars,
         ...builderVars,
-      }))
+      })))
+      this.#varsCacheSources = sources
+      return this.#varsCache
     } catch (err) {
       throw new Error(
         `Failed to resolve vars for page "${this.pageInfo?.path ?? '<unknown page>'}": ${err instanceof Error ? err.message : String(err)}`,
@@ -171,6 +192,18 @@ export class PageData {
    */
   get workers () {
     return this.workerFiles
+  }
+
+  /**
+   * Read the raw markdown body for a markdown page, excluding front matter.
+   * @returns {Promise<string>}
+   */
+  async readMarkdownContent () {
+    if (!this.pageInfo) throw new Error('A page is required to read markdown content')
+    if (this.pageInfo.type !== 'md') throw new Error('Markdown content can only be read from markdown pages')
+
+    const fileContents = await readFile(this.pageInfo.pageFile.filepath, 'utf8')
+    return parseMdFileContents(fileContents).markdownContent
   }
 
   /**

--- a/lib/build-pages/page-data.test.js
+++ b/lib/build-pages/page-data.test.js
@@ -1,18 +1,154 @@
+/**
+ * @import { PageInfo } from '../identify-pages.js'
+ * @import { ResolvedLayout } from './page-data.js'
+ * @import { BuilderOptions } from './page-builders/page-writer.js'
+ */
+
 import { test } from 'node:test'
 import assert from 'node:assert'
+import { mkdtemp, writeFile, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
 import { PageData } from './page-data.js'
 import { computePageUrl } from './compute-page-url.js'
 
+/**
+ * @typedef {Record<string, unknown> & { layout: string, title?: string, fromGlobalData?: boolean }} TestVars
+ */
+
+/** @type {BuilderOptions} */
+const builderOptions = {}
+
+/** @type {ResolvedLayout<TestVars, string, string>} */
+const fakeLayout = {
+  name: 'default',
+  render: async ({ children }) => String(children),
+  layoutStylePath: null,
+  layoutClientPath: null,
+}
+
+/**
+ * @param {string} filepath
+ * @returns {PageInfo}
+ */
+function mdPageInfo (filepath) {
+  return {
+    pageFile: {
+      root: '',
+      filepath,
+      relname: 'blog/post/test.md',
+      basename: 'test.md',
+      parentName: 'blog/post',
+      type: 'md',
+    },
+    type: 'md',
+    path: 'blog/post',
+    url: '/blog/post/',
+    outputName: 'index.html',
+    outputRelname: 'blog/post/index.html',
+    draft: false,
+  }
+}
+
 test.describe('PageData.vars', () => {
-  test('throws with page path before initialization', () => {
+  test('returns a cached, frozen vars object and invalidates when sources change', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'domstack-pagedata-cache-test-'))
+    const mdFile = join(dir, 'test.md')
+
+    try {
+      await writeFile(mdFile, '# Test\n\nContent.')
+
+      /** @type {PageData<TestVars, string, string>} */
+      const pd = new PageData({
+        pageInfo: mdPageInfo(mdFile),
+        globalVars: { layout: 'default', title: 'Global title' },
+        globalStyle: undefined,
+        globalClient: undefined,
+        defaultStyle: null,
+        defaultClient: null,
+        builderOptions,
+      })
+
+      await pd.init({ layouts: { default: fakeLayout } })
+
+      const vars = pd.vars
+      assert.strictEqual(pd.vars, vars, 'repeated access should return the cached object')
+      assert.strictEqual(Object.isFrozen(vars), true, 'cached vars should be frozen')
+      assert.strictEqual(vars.title, 'Test')
+      assert.throws(() => {
+        vars.title = 'Mutated title'
+      }, TypeError)
+      assert.strictEqual(vars.title, 'Test')
+
+      pd.globalDataVars = { fromGlobalData: true }
+
+      const updatedVars = pd.vars
+      assert.notStrictEqual(updatedVars, vars, 'replacing a source object should invalidate the cache')
+      assert.strictEqual(Object.isFrozen(updatedVars), true, 'updated cached vars should be frozen')
+      assert.strictEqual(updatedVars.fromGlobalData, true)
+      assert.strictEqual(updatedVars.title, 'Test')
+      assert.strictEqual(pd.vars, updatedVars, 'updated vars should be cached')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('reads markdown content without front matter', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'domstack-pagedata-md-content-test-'))
+    const mdFile = join(dir, 'test.md')
+
+    try {
+      await writeFile(mdFile, '---\ntitle: Front matter title\n---\n# Markdown title\n\nContent.')
+
+      const pd = new PageData({
+        pageInfo: mdPageInfo(mdFile),
+        globalVars: {},
+        globalStyle: undefined,
+        globalClient: undefined,
+        defaultStyle: null,
+        defaultClient: null,
+        builderOptions,
+      })
+
+      assert.strictEqual(await pd.readMarkdownContent(), '\n# Markdown title\n\nContent.')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects markdown content reads for non-markdown pages', async () => {
+    const pageInfo = mdPageInfo('test.html')
+    pageInfo.type = 'html'
+    pageInfo.pageFile.type = 'html'
+
     const pd = new PageData({
-      pageInfo: /** @type {any} */ ({ path: 'blog/test-post' }),
+      pageInfo,
       globalVars: {},
       globalStyle: undefined,
       globalClient: undefined,
       defaultStyle: null,
       defaultClient: null,
-      builderOptions: /** @type {any} */ ({}),
+      builderOptions,
+    })
+
+    await assert.rejects(
+      () => pd.readMarkdownContent(),
+      /Markdown content can only be read from markdown pages/
+    )
+  })
+
+  test('throws with page path before initialization', () => {
+    const pd = new PageData({
+      pageInfo: {
+        ...mdPageInfo('test.md'),
+        path: 'blog/test-post',
+      },
+      globalVars: {},
+      globalStyle: undefined,
+      globalClient: undefined,
+      defaultStyle: null,
+      defaultClient: null,
+      builderOptions,
     })
 
     assert.throws(
@@ -30,13 +166,13 @@ test.describe('PageData.vars', () => {
 
   test('error message includes unknown page fallback when pageInfo has no path', () => {
     const pd = new PageData({
-      pageInfo: /** @type {any} */ ({}),
+      pageInfo: /** @type {PageInfo} */ (/** @type {unknown} */ ({})),
       globalVars: {},
       globalStyle: undefined,
       globalClient: undefined,
       defaultStyle: null,
       defaultClient: null,
-      builderOptions: /** @type {any} */ ({}),
+      builderOptions,
     })
 
     assert.throws(


### PR DESCRIPTION
Closes #228

Adds `global.data.js` caveats documentation and updates `PageData` behavior to match the documented API.

Changes:

- Cache the merged `page.vars` object after the first successful access.
- Return a shallow-frozen vars object so callers treat it as read-only.
- Invalidate the vars cache if any source object reference changes, including `globalDataVars`.
- Add `page.readMarkdownContent()` for reading the raw markdown body without front matter.
- Share markdown front matter splitting between the markdown builder and `readMarkdownContent()`.
- Document that `page.vars` can throw when a page failed to initialize, and that this should be treated as a build issue to fix.
- Clarify that markdown raw source is not exposed as `page.vars.content` by default.
- Document that `renderInnerPage({ pages })` is available in `global.data.js`.

Validation:

- `node --test lib/build-pages/page-data.test.js lib/build-pages/page-data-vars-catch.test.js`
- `npx eslint lib/build-pages/page-data.js lib/build-pages/page-data.test.js lib/build-pages/page-builders/md/index.js lib/build-pages/page-builders/md/parse-md.js`
- `npm run test:tsc`