### PR TITLE
Add template return type selection guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,9 +879,9 @@ export default templateIterator
 
 Use the simplest return type that fits your needs:
 
-| Return type | Multiple outputs | Custom filename | Use when |
+| Return type | Multiple outputs | Custom output path | Use when |
 |---|---|---|---|
-| String | No | No (derived from template filename) | Single file, filename from template name |
+| String | No | No (derived from template filename) | Single file, output path derived from template filename |
 | Object | No | Yes | Single file with a custom output path |
 | Array | Yes | Yes | Fixed set of output files known at build time |
 | AsyncIterator | Yes | Yes | Dynamic or unknown number of outputs at build time |

--- a/README.md
+++ b/README.md
@@ -875,6 +875,19 @@ This is just a file with access to global vars: ${testVar}`,
 export default templateIterator
 ```
 
+### Choosing a template return type
+
+Use the simplest return type that fits your needs:
+
+| Return type | Multiple outputs | Custom filename | Use when |
+|---|---|---|---|
+| String | No | No (derived from template filename) | Single file, filename from template name |
+| Object | No | Yes | Single file with a custom output path |
+| Array | Yes | Yes | Fixed set of output files known at build time |
+| AsyncIterator | Yes | Yes | Any async work, or a dynamic number of outputs |
+
+Start with a string return and only switch to a more complex type when you need what it provides. An async generator is the right choice when you need to do async work (such as calling `renderInnerPage` on multiple pages) and produce more than one output file.
+
 ### RSS Feed Template Example
 
 Templates receive the standard variables available to pages, so its possible to perform page introspection and generate RSS feeds of website content.

--- a/README.md
+++ b/README.md
@@ -884,9 +884,9 @@ Use the simplest return type that fits your needs:
 | String | No | No (derived from template filename) | Single file, filename from template name |
 | Object | No | Yes | Single file with a custom output path |
 | Array | Yes | Yes | Fixed set of output files known at build time |
-| AsyncIterator | Yes | Yes | Any async work, or a dynamic number of outputs |
+| AsyncIterator | Yes | Yes | Dynamic or unknown number of outputs at build time |
 
-Start with a string return and only switch to a more complex type when you need what it provides. An async generator is the right choice when you need to do async work (such as calling `renderInnerPage` on multiple pages) and produce more than one output file.
+Start with a string return and only switch to a more complex type when you need what it provides. All template forms can do async work (string, object, and array all support `async` functions). Choose AsyncIterator specifically when the number of output files is not known until the template runs, or when you want to stream outputs one at a time rather than building the full list in memory first.
 
 ### RSS Feed Template Example
 


### PR DESCRIPTION
Closes #231

The README documents all four template return types with full examples but presents them as equal options. Without guidance, users default to more complex patterns (array returns for single-file templates) when simpler ones would do.

This adds a "Choosing a template return type" comparison table before the RSS Feed Template Example. The table maps each return type to whether it supports multiple outputs, a custom filename, and when to reach for it. The guidance is: start with a string return and only switch to something more complex when you need what it provides.