### PR TITLE
Document default layout renderer alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -1295,6 +1295,8 @@ npm install async-htm-to-string
 ```js
 import { html, rawHtml } from 'async-htm-to-string'
 
+// Note: rawHtml(children) assumes children is a pre-rendered HTML string from a
+// trusted source such as page.renderInnerPage(). Do not pass unsanitized user input.
 export default async function layout ({ children, vars }) {
   return await html`
     <!DOCTYPE html>
@@ -1308,7 +1310,7 @@ export default async function layout ({ children, vars }) {
 
 Key differences from `htm/preact`:
 
-- **Attribute names are standard HTML.** Use `class`, `for`, `tabindex` rather than `className`, `htmlFor`, `tabIndex`. Using React-style attribute names with `async-htm-to-string` outputs them literally as invalid attributes with no warning.
+- **Attribute names are standard HTML.** Use `class` and `for` rather than React aliases like `className` and `htmlFor`, which `async-htm-to-string` will output literally with no warning. For attributes like `tabindex`, `tabIndex` is only a casing preference in HTML, but using standard lowercase keeps templates consistent.
 - **Always `await` the `html` tag.** The tag returns an object that resolves to a string asynchronously. If you return it without `await` from a non-async function (or assign it where a string is expected), you will get `[object Object]` in the output with no error thrown. Use `async function` and `await` the result.
 - **`rawHtml()` bypasses escaping.** It is equivalent to setting `innerHTML` directly. Use it only for HTML you generated yourself (such as the output of `page.renderInnerPage()` or a trusted markdown renderer). `children` passed to a layout can be any type returned by a page function, and may contain unsanitized content depending on the page. Always verify the source before passing it through `rawHtml()`.
 

--- a/README.md
+++ b/README.md
@@ -1296,7 +1296,7 @@ npm install async-htm-to-string
 import { html, rawHtml } from 'async-htm-to-string'
 
 // Note: rawHtml(children) assumes children is a pre-rendered HTML string from a
-// trusted source such as page.renderInnerPage(). Do not pass unsanitized user input.
+// trusted source such as await page.renderInnerPage({ pages }). Do not pass unsanitized user input.
 export default async function layout ({ children, vars }) {
   return await html`
     <!DOCTYPE html>
@@ -1312,13 +1312,13 @@ Key differences from `htm/preact`:
 
 - **Attribute names are standard HTML.** Use `class` and `for` rather than React aliases like `className` and `htmlFor`, which `async-htm-to-string` will output literally with no warning. For attributes like `tabindex`, `tabIndex` is only a casing preference in HTML, but using standard lowercase keeps templates consistent.
 - **Always `await` the `html` tag.** The tag returns an object that resolves to a string asynchronously. If you return it without `await` from a non-async function (or assign it where a string is expected), you will get `[object Object]` in the output with no error thrown. Use `async function` and `await` the result.
-- **`rawHtml()` bypasses escaping.** It is equivalent to setting `innerHTML` directly. Use it only for HTML you generated yourself (such as the output of `page.renderInnerPage()` or a trusted markdown renderer). `children` passed to a layout can be any type returned by a page function, and may contain unsanitized content depending on the page. Always verify the source before passing it through `rawHtml()`.
+- **`rawHtml()` bypasses escaping.** It is equivalent to setting `innerHTML` directly. Use it only for HTML you generated yourself (such as the output of `await page.renderInnerPage({ pages })` or a trusted markdown renderer). `children` passed to a layout can be any type returned by a page function, and may contain unsanitized content depending on the page. Always verify the source before passing it through `rawHtml()`.
 
 ```js
 import { html, rawHtml } from 'async-htm-to-string'
 
 // safe: vars.title is escaped automatically
-// children here is the HTML string produced by page.renderInnerPage() — trusted
+// children here is the HTML string produced by await page.renderInnerPage({ pages }) — trusted
 export default async function layout ({ children, vars }) {
   return await html`<main class="content"><h1>${vars.title}</h1>${rawHtml(children)}</main>`
 }

--- a/README.md
+++ b/README.md
@@ -1288,6 +1288,10 @@ const layout: LayoutFunction<{site: string}, VDOMNode, string> = ({ children }) 
 
 DomStack's default layout pattern uses `htm/preact` and `preact-render-to-string` for HTML generation. If you only need server-side rendering and have no client-side Preact components, [`async-htm-to-string`](https://github.com/nicferrier/async-htm-to-string) is a lighter alternative. It uses the same `htm` tagged template syntax but renders directly to a string without a virtual DOM layer.
 
+```console
+npm install async-htm-to-string
+```
+
 ```js
 import { html, rawHtml } from 'async-htm-to-string'
 
@@ -1305,14 +1309,14 @@ export default async function layout ({ children, vars }) {
 Key differences from `htm/preact`:
 
 - **Attribute names are standard HTML.** Use `class`, `for`, `tabindex` rather than `className`, `htmlFor`, `tabIndex`. Using React-style attribute names with `async-htm-to-string` outputs them literally as invalid attributes with no warning.
-- **Always `await` the `html` tag.** It returns a thenable object, not a plain string. Returning without `await` produces `[object Object]` in the rendered output with no error thrown.
-- **`rawHtml()` bypasses escaping.** Use it only for content you trust, such as the output of `page.renderInnerPage()` or your own markdown renderer. Passing user-controlled input through `rawHtml()` is a direct XSS risk.
+- **Always `await` the `html` tag.** The tag returns an object that resolves to a string asynchronously. If you return it without `await` from a non-async function (or assign it where a string is expected), you will get `[object Object]` in the output with no error thrown. Use `async function` and `await` the result.
+- **`rawHtml()` bypasses escaping.** It is equivalent to setting `innerHTML` directly. Use it only for HTML you generated yourself (such as the output of `page.renderInnerPage()` or a trusted markdown renderer). `children` passed to a layout can be any type returned by a page function, and may contain unsanitized content depending on the page. Always verify the source before passing it through `rawHtml()`.
 
 ```js
 import { html, rawHtml } from 'async-htm-to-string'
 
 // safe: vars.title is escaped automatically
-// trusted: children is already-rendered HTML from the page builder
+// children here is the HTML string produced by page.renderInnerPage() — trusted
 export default async function layout ({ children, vars }) {
   return await html`<main class="content"><h1>${vars.title}</h1>${rawHtml(children)}</main>`
 }

--- a/README.md
+++ b/README.md
@@ -1284,6 +1284,40 @@ const layout: LayoutFunction<{site: string}, VDOMNode, string> = ({ children }) 
 }
 ```
 
+### Using `async-htm-to-string` for string-based rendering
+
+DomStack's default layout pattern uses `htm/preact` and `preact-render-to-string` for HTML generation. If you only need server-side rendering and have no client-side Preact components, [`async-htm-to-string`](https://github.com/nicferrier/async-htm-to-string) is a lighter alternative. It uses the same `htm` tagged template syntax but renders directly to a string without a virtual DOM layer.
+
+```js
+import { html, rawHtml } from 'async-htm-to-string'
+
+export default async function layout ({ children, vars }) {
+  return await html`
+    <!DOCTYPE html>
+    <html lang="${vars.lang}">
+      <head><title>${vars.title}</title></head>
+      <body>${rawHtml(children)}</body>
+    </html>
+  `
+}
+```
+
+Key differences from `htm/preact`:
+
+- **Attribute names are standard HTML.** Use `class`, `for`, `tabindex` rather than `className`, `htmlFor`, `tabIndex`. Using React-style attribute names with `async-htm-to-string` outputs them literally as invalid attributes with no warning.
+- **Always `await` the `html` tag.** It returns a thenable object, not a plain string. Returning without `await` produces `[object Object]` in the rendered output with no error thrown.
+- **`rawHtml()` bypasses escaping.** Use it only for content you trust, such as the output of `page.renderInnerPage()` or your own markdown renderer. Passing user-controlled input through `rawHtml()` is a direct XSS risk.
+
+```js
+import { html, rawHtml } from 'async-htm-to-string'
+
+// safe: vars.title is escaped automatically
+// trusted: children is already-rendered HTML from the page builder
+export default async function layout ({ children, vars }) {
+  return await html`<main class="content"><h1>${vars.title}</h1>${rawHtml(children)}</main>`
+}
+```
+
 ## Design Goals
 
 - Convention over configuration. All configuration should be optional, and at most it should be minimal.

--- a/README.md
+++ b/README.md
@@ -364,10 +364,13 @@ await funnyLibrary()
 
 #### .tsx/.jsx
 
-Client bundles support .jsx and .tsx through esbuild. DOMStack does not include a JSX runtime by default; install the runtime you want and configure it with `esbuild.settings`.
-See the [react](./examples/react/) and [preact-isomorphic](./examples/preact-isomorphic/) examples for more details.
+Client bundles support `.jsx` and `.tsx` through esbuild.
+DOMStack does not include a JSX runtime by default.
+Install the runtime you want and configure it with `esbuild.settings`.
+[Preact][preact] is the recommended JSX runtime for DomStack because it is small, browser-focused, and works well with page-scoped client bundles.
+See the [preact-isomorphic](./examples/preact-isomorphic/) and [react](./examples/react/) examples for complete projects.
 
-For example, to use [Preact][preact] in browser JSX/TSX bundles, add it to your project and opt into Preact's automatic JSX runtime:
+To use Preact in browser JSX/TSX bundles, add it to your project and opt into Preact's automatic JSX runtime:
 
 ```console
 npm install preact
@@ -378,6 +381,35 @@ npm install preact
 export default async function esbuildSettingsOverride (esbuildSettings) {
   esbuildSettings.jsx = 'automatic'
   esbuildSettings.jsxImportSource = 'preact'
+
+  return esbuildSettings
+}
+```
+
+If a dependency expects React, you can often swap React for `@preact/compat` with an npm package alias.
+This installs `@preact/compat` into `node_modules/react`.
+See [Simple TanStack Query in Preact](https://bret.io/blog/2026/simple-tanstack-query-in-preact/) for more details.
+
+```json
+{
+  "dependencies": {
+    "react": "npm:@preact/compat@^18.3.1"
+  }
+}
+```
+
+React also works if your project needs React-specific APIs or ecosystem packages.
+To use React in browser JSX/TSX bundles, add React to your project and opt into React's automatic JSX runtime:
+
+```console
+npm install react react-dom
+```
+
+```js
+// src/esbuild.settings.js
+export default async function esbuildSettingsOverride (esbuildSettings) {
+  esbuildSettings.jsx = 'automatic'
+  esbuildSettings.jsxImportSource = 'react'
 
   return esbuildSettings
 }
@@ -1168,7 +1200,10 @@ const esbuildSettingsOverride = async (esbuildSettings: BuildOptions): Promise<B
 export default esbuildSettingsOverride
 ```
 
-DOMStack passes its default `BuildOptions` into this function, including Preact JSX defaults and asset loader defaults for common images, icons, and fonts. You can return a shallow copy that modifies those defaults when you only need a small change. For example, this keeps DOMStack's default asset loaders and adds a custom loader for `.wasm` files:
+DOMStack passes its default `BuildOptions` into this function, including asset loader defaults for common images, icons, and fonts.
+DOMStack does not set a JSX runtime by default.
+You can return a shallow copy that modifies those defaults when you only need a small change.
+For example, this keeps DOMStack's default asset loaders and adds a custom loader for `.wasm` files:
 
 ```typescript
 import type { BuildOptions } from '@domstack/static/types.js'
@@ -1186,7 +1221,8 @@ const esbuildSettingsOverride = async (esbuildSettings: BuildOptions): Promise<B
 export default esbuildSettingsOverride
 ```
 
-If you want full control, reset DOMStack's convenience defaults back to esbuild's defaults while preserving the required DOMStack build wiring (`entryPoints`, `outdir`, `outbase`, etc.). From there, define only the settings you want:
+If you want full control, reset DOMStack's convenience defaults back to esbuild's defaults while preserving the required DOMStack build wiring (`entryPoints`, `outdir`, `outbase`, etc.).
+From there, define only the settings you want:
 
 ```typescript
 import type { BuildOptions } from '@domstack/static/types.js'
@@ -1438,6 +1474,94 @@ const layout: LayoutFunction<{site: string}, VDOMNode, string> = ({ children }) 
   return `<html><body>${html}</body></html>`
 }
 ```
+
+### Swapping the default layout template renderer
+
+DOMStack's bundled default layout uses [`fragtml`][fragtml] because the default template only needs safe string manipulation.
+You can eject or replace that layout with any Node-compatible renderer that returns an HTML string.
+The previous incumbent for this job was `htm/preact` with `preact-render-to-string`.
+That is still a good fit when your Node-side pages or layouts produce Preact VNodes, or when you want the same component model on the server and in browser bundles.
+If you also want Preact or React in browser JSX/TSX bundles, configure that separately as described in [`.tsx/.jsx`](#tsxjsx).
+
+```console
+npm install htm preact preact-render-to-string
+```
+
+```js
+/**
+ * @import { LayoutFunction } from '@domstack/static/types.js'
+ * @import { VNode } from 'preact'
+ */
+import { html } from 'htm/preact'
+import { render } from 'preact-render-to-string'
+
+/** @type {LayoutFunction<Record<string, any>, string | VNode, string>} */
+export default function rootLayout ({ children, vars, scripts, styles }) {
+  return `<!DOCTYPE html>
+${render(html`
+    <html lang=${vars.lang ?? 'en'}>
+      <head>
+        <title>${vars.title}</title>
+        ${styles?.map(style => html`<link rel="stylesheet" href=${style} />`)}
+        ${scripts?.map(script => html`<script type="module" src=${script}></script>`)}
+      </head>
+      <body>
+        ${typeof children === 'string'
+          ? html`<main dangerouslySetInnerHTML=${{ __html: children }} />`
+          : html`<main>${children}</main>`}
+      </body>
+    </html>
+  `)}`
+}
+```
+
+`preact-render-to-string` works, but it builds a virtual DOM tree just to serialize layout HTML.
+For layouts that mostly combine strings and already-rendered page content, [`async-htm-to-string`](https://github.com/voxpelli/async-htm-to-string) keeps the familiar HTM tagged-template style while rendering directly to strings.
+That can be a better-performing and more direct tool for server-only layout templates.
+You can still use Preact for browser-side components and use `async-htm-to-string` for Node-side layout rendering.
+
+```console
+npm install async-htm-to-string
+```
+
+```js
+/**
+ * @import { LayoutFunction } from '@domstack/static/types.js'
+ */
+import { html, rawHtml } from 'async-htm-to-string'
+
+/** @type {LayoutFunction<Record<string, any>, string, Promise<string>>} */
+export default async function rootLayout ({ children, vars, scripts, styles }) {
+  return await html`
+    <!DOCTYPE html>
+    <html lang="${vars.lang ?? 'en'}">
+      <head>
+        <title>${vars.title}</title>
+        ${styles?.map(style => html`<link rel="stylesheet" href="${style}" />`)}
+        ${scripts?.map(script => html`<script type="module" src="${script}"></script>`)}
+      </head>
+      <body>
+        <main>${rawHtml(children)}</main>
+      </body>
+    </html>
+  `
+}
+```
+
+Key differences from `htm/preact` and DOMStack's `fragtml` default:
+
+- **Attribute names are standard HTML.**
+Use `class` and `for` rather than React aliases like `className` and `htmlFor`, which `async-htm-to-string` will output literally with no warning.
+For attributes like `tabindex`, `tabIndex` is only a casing preference in HTML, but using standard lowercase keeps templates consistent.
+- **Always `await` the `html` tag.**
+The tag returns an object that resolves to a string asynchronously.
+If you return it without `await` from a non-async function, or assign it where a string is expected, you will get `[object Object]` in the output with no error thrown.
+Use `async function` and `await` the result.
+- **`rawHtml()` bypasses escaping.**
+It is equivalent to setting `innerHTML` directly.
+Use it only for HTML you generated yourself, such as the output of `await page.renderInnerPage({ pages })` or a trusted markdown renderer.
+`children` passed to a layout can be any type returned by a page function, and may contain unsanitized content depending on the page.
+Always verify the source before passing it through `rawHtml()`.
 
 ## Design Goals
 


### PR DESCRIPTION
Closes #239

This PR documents how to swap DomStack's `fragtml` default layout renderer for the previous HTM/Preact approach using `htm/preact` and `preact-render-to-string`.

It also presents [`async-htm-to-string`](https://github.com/voxpelli/async-htm-to-string) as a more direct and potentially more performant alternative for server-only layout templates that mostly combine strings and already-rendered page HTML.

The README now covers:

- How to configure browser JSX/TSX bundles now that DomStack no longer ships a default JSX runtime.
- Why Preact is the recommended JSX runtime for DomStack client bundles.
- How to alias React dependencies to `@preact/compat`, with a link to https://bret.io/blog/2026/simple-tanstack-query-in-preact/ for more detail.
- How to configure React when a project needs React-specific APIs or ecosystem packages.
- How to write a custom layout using `htm/preact` and `preact-render-to-string`.
- How to write a similar layout using `async-htm-to-string`.
- Important `async-htm-to-string` gotchas around standard HTML attributes, awaiting `html`, and `rawHtml()` safety.
