### PR TITLE
Improve DomStack programmatic build testing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,29 @@ domstack (v11.0.0)
 `domstack` is primarily a unix `bin` written for the [Node.js](https://nodejs.org) runtime that is intended to be installed from `npm` as a `devDependency` inside a `package.json` committed to a `git` repository.
 It can be used outside of this context, but it works best within it.
 
+## Programmatic test builds
+
+Use the top-level `testBuild` helper to build into a temporary directory from tests without managing setup and cleanup yourself.
+
+```js
+import { test } from 'node:test'
+import assert from 'node:assert'
+import { testBuild } from '@domstack/static'
+
+test('site output', async () => {
+  const build = await testBuild('./src')
+
+  try {
+    const html = await build.readOutput('index.html')
+    assert.match(html, /Hello/)
+  } finally {
+    await build.cleanup()
+  }
+})
+```
+
+`testBuild(src, opts)` creates a temporary destination directory, runs `new DomStack(src, dest, opts).build()`, and returns `{ dest, results, readOutput, cleanup }`. Options are passed through to `DomStack`, including `copy` paths.
+
 ## Core Concepts
 
 `domstack` is a static site generator that builds a website from "pages" in a `src` directory, nearly 1:1 into a `dest` directory.
@@ -744,6 +767,8 @@ It is recomended to eject early in your project so that you can customize the ro
 You can specify directories to copy into your `dest` directory using the `--copy` flag. Everything in those directories will be copied as-is into the destination, including js, css, html and markdown, preserving the internal directory structure. Conflicting files are not detected or reported and will cause undefined behavior.
 
 Copy folders must live **outside** of the `dest` directory. Copy directories can be in the src directory allowing for nested builds. In this case they are added to the ignore glob and ignored by the rest of `domstack`.
+
+When using the programmatic `DomStack` constructor, `copy` entries may be relative or absolute paths. Relative `copy` paths are resolved to absolute paths from the current working directory, matching the CLI `--copy` behavior, before they are stored on `domstack.opts.copy` and passed to the copy build step.
 
 This is useful when you have legacy or archived site content that you want to include in your site, but don't want `domstack` to process or modify it.
 In general, static content should live in your primary `src` directory, however for merging in old static assets over your domstack build is sometimes easier to reason about when it's kept in a separate folder and isn't processed in any way.

--- a/index.js
+++ b/index.js
@@ -160,8 +160,7 @@ export class DomStack {
     this.#src = src
     this.#dest = dest
 
-    const basedir = dirname(resolve(src))
-    const copyDirs = (opts?.copy ?? []).map(dir => resolve(basedir, dir))
+    const copyDirs = (opts?.copy ?? []).map(dir => resolve(dir))
 
     this.opts = {
       ...opts,

--- a/index.js
+++ b/index.js
@@ -160,10 +160,12 @@ export class DomStack {
     this.#src = src
     this.#dest = dest
 
-    const copyDirs = opts?.copy ?? []
+    const basedir = dirname(resolve(src))
+    const copyDirs = (opts?.copy ?? []).map(dir => resolve(basedir, dir))
 
     this.opts = {
       ...opts,
+      copy: copyDirs,
       ignore: [
         ...DEFAULT_IGNORES,
         basename(dest),
@@ -172,12 +174,11 @@ export class DomStack {
       ],
     }
 
-    if (copyDirs && copyDirs.length > 0) {
+    if (copyDirs.length > 0) {
       const absDest = resolve(this.#dest)
       for (const copyDir of copyDirs) {
         // Copy dirs can be in the src dir (nested builds), but not in the dest dir.
-        const absCopyDir = resolve(copyDir)
-        const relToDest = relative(absDest, absCopyDir)
+        const relToDest = relative(absDest, copyDir)
         if (relToDest === '' || !relToDest.startsWith('..')) {
           throw new Error(`copyDir ${copyDir} is within the dest directory`)
         }

--- a/index.js
+++ b/index.js
@@ -14,8 +14,10 @@
 */
 import { once } from 'events'
 import assert from 'node:assert'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import chokidar from 'chokidar'
-import { basename, dirname, relative, resolve } from 'node:path'
+import { basename, dirname, join, relative, resolve } from 'node:path'
 // @ts-expect-error
 import makeArray from 'make-array'
 import ignore from 'ignore'
@@ -135,6 +137,14 @@ export { PageData } from './lib/build-pages/page-data.js'
  * @typedef {TemplateFunctionParams<Vars>} TemplateFunctionParams
  */
 
+/**
+ * @typedef TestBuildResult
+ * @property {string} dest - Temporary destination directory used for the build.
+ * @property {Results} results - DomStack build results.
+ * @property {(path: string) => Promise<string>} readOutput - Read a UTF-8 file from the temporary destination directory.
+ * @property {() => Promise<void>} cleanup - Remove the temporary destination directory.
+ */
+
 const DEFAULT_IGNORES = /** @type {const} */ ([
   '.*',
   'coverage',
@@ -179,6 +189,10 @@ export class DomStack {
   #buildLock = Promise.resolve()
 
   /**
+   * Create a DomStack build instance.
+   *
+   * Copy paths supplied through `opts.copy` are resolved to absolute paths from
+   * the current working directory, matching the CLI `--copy` behavior.
    *
    * @param {string} src - The src path of the page build
    * @param {string} dest - The dest path of the page build
@@ -192,10 +206,11 @@ export class DomStack {
     this.#src = src
     this.#dest = dest
 
-    const copyDirs = opts?.copy ?? []
+    const copyDirs = (opts?.copy ?? []).map(dir => resolve(dir))
 
     this.opts = {
       ...opts,
+      copy: copyDirs,
       ignore: [
         ...DEFAULT_IGNORES,
         basename(dest),
@@ -204,12 +219,11 @@ export class DomStack {
       ],
     }
 
-    if (copyDirs && copyDirs.length > 0) {
+    if (copyDirs.length > 0) {
       const absDest = resolve(this.#dest)
       for (const copyDir of copyDirs) {
         // Copy dirs can be in the src dir (nested builds), but not in the dest dir.
-        const absCopyDir = resolve(copyDir)
-        const relToDest = relative(absDest, absCopyDir)
+        const relToDest = relative(absDest, copyDir)
         if (relToDest === '' || !relToDest.startsWith('..')) {
           throw new Error(`copyDir ${copyDir} is within the dest directory`)
         }
@@ -766,6 +780,26 @@ export class DomStack {
    */
   async settled () {
     await this.#buildLock
+  }
+}
+
+/**
+ * Build a DomStack site into a temporary directory for isolated tests.
+ *
+ * @param {string} src - Source directory to build.
+ * @param {DomStackOpts} [opts] - DomStack build options.
+ * @returns {Promise<TestBuildResult>}
+ */
+export async function testBuild (src, opts = {}) {
+  const dest = await mkdtemp(join(tmpdir(), 'domstack-test-'))
+  const domstack = new DomStack(resolve(src), dest, opts)
+  const results = await domstack.build()
+
+  return {
+    dest,
+    results,
+    readOutput: path => readFile(join(dest, path), 'utf8'),
+    cleanup: () => rm(dest, { recursive: true, force: true }),
   }
 }
 

--- a/lib/build-pages/index.js
+++ b/lib/build-pages/index.js
@@ -1,6 +1,7 @@
 /**
  * @import { BuilderOptions } from './page-builders/page-writer.js'
  * @import { BuildStep, SiteData, DomStackOpts } from '../builder.js'
+ * @import { PageInfo, TemplateInfo } from '../identify-pages.js'
  * @import { ResolvedLayout } from './page-data.js'
  */
 
@@ -63,7 +64,14 @@ const __dirname = import.meta.dirname
  */
 
 /**
-  * @typedef {Omit<PageBuildStepResult, 'errors'> & { errors: {error: Error, errorData?: object}[] }} WorkerBuildStepResult
+ * Error metadata sent back from the page build worker.
+ * @typedef {object} WorkerErrorData
+ * @property {PageInfo} [page] - Page context for page var/rendering errors.
+ * @property {TemplateInfo} [template] - Template context for template rendering errors.
+ */
+
+/**
+  * @typedef {Omit<PageBuildStepResult, 'errors'> & { errors: {error: Error, errorData?: WorkerErrorData}[] }} WorkerBuildStepResult
  */
 
 /**
@@ -76,6 +84,46 @@ const __dirname = import.meta.dirname
  */
 
 export { pageBuilders }
+
+/**
+ * @param {WorkerErrorData} errorData
+ * @returns {{ type: 'page' | 'template', path: string } | null}
+ */
+function getWorkerErrorContext (errorData) {
+  if (errorData.page) {
+    const pagePath = errorData.page.path || errorData.page.url || errorData.page.pageFile.relname
+    return { type: 'page', path: pagePath }
+  }
+
+  if (errorData.template) {
+    const templatePath = errorData.template.path || errorData.template.templateFile.relname
+    return { type: 'template', path: templatePath }
+  }
+
+  return null
+}
+
+/**
+ * @param {Error} error
+ * @param {WorkerErrorData} errorData
+ * @returns {Error}
+ */
+function restoreWorkerError (error, errorData) {
+  const context = getWorkerErrorContext(errorData)
+  const message = context
+    ? `${error.message} (${context.type}: "${context.path}")`
+    : error.message
+  const restoredError = new Error(message, { cause: error.cause })
+  restoredError.name = error.name
+
+  if (error.stack) {
+    restoredError.stack = error.stack.replace(error.message, restoredError.message)
+  }
+
+  Object.assign(restoredError, errorData)
+
+  return restoredError
+}
 
 /**
  * Page builder glue. Most of the magic happens in the builders.
@@ -105,13 +153,8 @@ export function buildPages (src, dest, siteData, opts) {
       }
 
       if (workerReport.errors.length > 0) {
-        // Put the errorData on the error to be consistent with the rest of the builders.
         buildReport.errors = workerReport.errors.map(({ error, errorData = {} }) => {
-          for (const [key, val] of Object.entries(errorData)) {
-            // @ts-ignore
-            error[key] = val
-          }
-          return error
+          return restoreWorkerError(error, errorData)
         })
       }
       resolve(buildReport)

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -45,12 +45,12 @@ import { ensureDest } from './helpers/ensure-dest.js'
 
 /**
  * @typedef DomStackOpts
- * @property {boolean|undefined} [static=true] - Enable/disable static file processing
- * @property {boolean|undefined} [metafile=true] - Enable/disable the writing of the esbuild metadata file.
- * @property {string[]|undefined} [ignore=[]] - Array of ignore strings
- * @property {string[]|undefined} [target=[]] - Array of target strings to pass to esbuild
- * @property {boolean|undefined} [buildDrafts=false] - Build draft files with the published:false variable
- * @property {string[]|undefined} [copy=[]] - Array of paths to copy their contents into the dest directory
+ * @property {boolean|undefined} [static=true] - Enable copying non-page, non-bundle static files from `src` into `dest`.
+ * @property {boolean|undefined} [metafile=true] - Enable writing the esbuild metadata file.
+ * @property {string[]|undefined} [ignore=[]] - Ignore patterns applied while discovering and copying source files.
+ * @property {string[]|undefined} [target=[]] - Esbuild target values used for JavaScript and CSS bundling.
+ * @property {boolean|undefined} [buildDrafts=false] - Build files marked with the `published: false` variable.
+ * @property {string[]|undefined} [copy=[]] - Paths to copy into the dest directory. Relative paths are resolved to absolute paths from the current working directory by the DomStack constructor, matching the CLI `--copy` behavior.
  */
 
 /**

--- a/test-cases/constructor-copy-paths/index.test.js
+++ b/test-cases/constructor-copy-paths/index.test.js
@@ -1,0 +1,34 @@
+import { test } from 'node:test'
+import assert from 'node:assert'
+import { isAbsolute } from 'node:path'
+import { DomStack } from '../../index.js'
+
+test.describe('DomStack constructor - copy path resolution', () => {
+  test('resolves a relative copy path to an absolute path', () => {
+    const ds = new DomStack('/tmp/test-src', '/tmp/test-dest', {
+      copy: ['some-relative-copy-dir'],
+    })
+
+    assert.strictEqual(ds.opts.copy.length, 1, 'one copy entry')
+    assert.ok(isAbsolute(ds.opts.copy[0]), `copy path should be absolute, got: "${ds.opts.copy[0]}"`)
+  })
+
+  test('leaves an already-absolute copy path unchanged', () => {
+    const ds = new DomStack('/tmp/test-src', '/tmp/test-dest', {
+      copy: ['/absolute/copy/dir'],
+    })
+
+    assert.strictEqual(ds.opts.copy[0], '/absolute/copy/dir', 'absolute path is preserved')
+  })
+
+  test('resolves multiple mixed copy paths', () => {
+    const ds = new DomStack('/tmp/test-src', '/tmp/test-dest', {
+      copy: ['relative-dir', '/absolute/dir'],
+    })
+
+    assert.strictEqual(ds.opts.copy.length, 2, 'two copy entries')
+    for (const p of ds.opts.copy) {
+      assert.ok(isAbsolute(p), `each copy path should be absolute, got: "${p}"`)
+    }
+  })
+})

--- a/test-cases/constructor-copy-paths/index.test.js
+++ b/test-cases/constructor-copy-paths/index.test.js
@@ -1,11 +1,15 @@
 import { test } from 'node:test'
 import assert from 'node:assert'
-import { isAbsolute } from 'node:path'
+import { isAbsolute, resolve, join } from 'node:path'
+import { tmpdir } from 'node:os'
 import { DomStack } from '../../index.js'
+
+const tmpSrc = join(tmpdir(), 'domstack-test-src')
+const tmpDest = join(tmpdir(), 'domstack-test-dest')
 
 test.describe('DomStack constructor - copy path resolution', () => {
   test('resolves a relative copy path to an absolute path', () => {
-    const ds = new DomStack('/tmp/test-src', '/tmp/test-dest', {
+    const ds = new DomStack(tmpSrc, tmpDest, {
       copy: ['some-relative-copy-dir'],
     })
 
@@ -13,17 +17,19 @@ test.describe('DomStack constructor - copy path resolution', () => {
     assert.ok(isAbsolute(ds.opts.copy[0]), `copy path should be absolute, got: "${ds.opts.copy[0]}"`)
   })
 
-  test('leaves an already-absolute copy path unchanged', () => {
-    const ds = new DomStack('/tmp/test-src', '/tmp/test-dest', {
-      copy: ['/absolute/copy/dir'],
+  test('leaves an already-absolute copy path normalized', () => {
+    const absPath = join(tmpdir(), 'absolute', 'copy', 'dir')
+    const ds = new DomStack(tmpSrc, tmpDest, {
+      copy: [absPath],
     })
 
-    assert.strictEqual(ds.opts.copy[0], '/absolute/copy/dir', 'absolute path is preserved')
+    assert.strictEqual(ds.opts.copy[0], resolve(absPath), 'absolute path is preserved and normalized')
   })
 
   test('resolves multiple mixed copy paths', () => {
-    const ds = new DomStack('/tmp/test-src', '/tmp/test-dest', {
-      copy: ['relative-dir', '/absolute/dir'],
+    const absPath = join(tmpdir(), 'absolute', 'dir')
+    const ds = new DomStack(tmpSrc, tmpDest, {
+      copy: ['relative-dir', absPath],
     })
 
     assert.strictEqual(ds.opts.copy.length, 2, 'two copy entries')

--- a/test-cases/constructor-copy-paths/index.test.js
+++ b/test-cases/constructor-copy-paths/index.test.js
@@ -14,7 +14,8 @@ test.describe('DomStack constructor - copy path resolution', () => {
     })
 
     assert.strictEqual(ds.opts.copy.length, 1, 'one copy entry')
-    assert.ok(isAbsolute(ds.opts.copy[0]), `copy path should be absolute, got: "${ds.opts.copy[0]}"`)
+    const copyPath = /** @type {string} */ (ds.opts.copy[0])
+    assert.ok(isAbsolute(copyPath), `copy path should be absolute, got: "${copyPath}"`)
   })
 
   test('leaves an already-absolute copy path normalized', () => {

--- a/test-cases/constructor-copy-paths/index.test.js
+++ b/test-cases/constructor-copy-paths/index.test.js
@@ -1,0 +1,41 @@
+import { test } from 'node:test'
+import assert from 'node:assert'
+import { isAbsolute, resolve, join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { DomStack } from '../../index.js'
+
+const tmpSrc = join(tmpdir(), 'domstack-test-src')
+const tmpDest = join(tmpdir(), 'domstack-test-dest')
+
+test.describe('DomStack constructor - copy path resolution', () => {
+  test('resolves a relative copy path to an absolute path', () => {
+    const ds = new DomStack(tmpSrc, tmpDest, {
+      copy: ['some-relative-copy-dir'],
+    })
+
+    assert.strictEqual(ds.opts.copy.length, 1, 'one copy entry')
+    const copyPath = /** @type {string} */ (ds.opts.copy[0])
+    assert.ok(isAbsolute(copyPath), `copy path should be absolute, got: "${copyPath}"`)
+  })
+
+  test('leaves an already-absolute copy path normalized', () => {
+    const absPath = join(tmpdir(), 'absolute', 'copy', 'dir')
+    const ds = new DomStack(tmpSrc, tmpDest, {
+      copy: [absPath],
+    })
+
+    assert.strictEqual(ds.opts.copy[0], resolve(absPath), 'absolute path is preserved and normalized')
+  })
+
+  test('resolves multiple mixed copy paths', () => {
+    const absPath = join(tmpdir(), 'absolute', 'dir')
+    const ds = new DomStack(tmpSrc, tmpDest, {
+      copy: ['relative-dir', absPath],
+    })
+
+    assert.strictEqual(ds.opts.copy.length, 2, 'two copy entries')
+    for (const p of ds.opts.copy) {
+      assert.ok(isAbsolute(p), `each copy path should be absolute, got: "${p}"`)
+    }
+  })
+})

--- a/test-cases/default-layout/index.test.js
+++ b/test-cases/default-layout/index.test.js
@@ -1,21 +1,19 @@
 import { test } from 'node:test'
 import assert from 'node:assert'
-import { DomStack } from '../../index.js'
+import { testBuild } from '../../index.js'
 import * as path from 'path'
-import { rm } from 'fs/promises'
 
 const __dirname = import.meta.dirname
 
 test.describe('default-layout', () => {
-  test('should build site with default layout', async () => {
+  test('should build site with default layout', async (t) => {
     const src = path.join(__dirname, './src')
-    const dest = path.join(__dirname, './public')
-    const siteUp = new DomStack(src, dest)
+    const build = await testBuild(src)
 
-    await rm(dest, { recursive: true, force: true })
+    t.after(async () => {
+      await build.cleanup()
+    })
 
-    await siteUp.build()
-
-    assert.ok(true, 'built with default layout')
+    assert.ok(build.results, 'built with default layout')
   })
 })

--- a/test-cases/drafts/index.test.js
+++ b/test-cases/drafts/index.test.js
@@ -1,22 +1,23 @@
 import { test } from 'node:test'
 import assert from 'node:assert'
-import { DomStack } from '../../index.js'
+import { testBuild } from '../../index.js'
 import * as path from 'path'
-import { rm, stat, readFile } from 'fs/promises'
+import { stat, readFile } from 'fs/promises'
 import * as cheerio from 'cheerio'
 import { allFiles } from 'async-folder-walker'
 
 const __dirname = import.meta.dirname
 
 test.describe('drafts', () => {
-  test('should build site with draft pages', async () => {
+  test('should build site with draft pages', async (t) => {
     const src = path.join(__dirname, './src')
-    const dest = path.join(__dirname, './public')
-    const siteUp = new DomStack(src, dest, { buildDrafts: true })
+    const build = await testBuild(src, { buildDrafts: true })
+    const { dest, results } = build
 
-    await rm(dest, { recursive: true, force: true })
+    t.after(async () => {
+      await build.cleanup()
+    })
 
-    const results = await siteUp.build()
     assert.ok(results, 'Domstack built site and returned build results')
 
     const pages = {

--- a/test-cases/general-features/index.test.js
+++ b/test-cases/general-features/index.test.js
@@ -1,8 +1,8 @@
 import { test } from 'node:test'
 import assert from 'node:assert'
-import { DomStack } from '../../index.js'
+import { testBuild } from '../../index.js'
 import * as path from 'path'
-import { rm, stat, readFile } from 'fs/promises'
+import { stat, readFile } from 'fs/promises'
 import * as cheerio from 'cheerio'
 import { allFiles } from 'async-folder-walker'
 
@@ -11,12 +11,13 @@ const __dirname = import.meta.dirname
 test.describe('general-features', () => {
   test('should build site with all features', async (t) => {
     const src = path.join(__dirname, './src')
-    const dest = path.join(__dirname, './public')
-    const siteUp = new DomStack(src, dest, { copy: [path.join(__dirname, './copyfolder')] })
+    const build = await testBuild(src, { copy: [path.join(__dirname, './copyfolder')] })
+    const { dest, results } = build
 
-    await rm(dest, { recursive: true, force: true })
+    t.after(async () => {
+      await build.cleanup()
+    })
 
-    const results = await siteUp.build()
     assert.ok(results, 'DomStack built site and returned build results')
 
     const globalAssets = {

--- a/test-cases/page-build-errors/index.test.js
+++ b/test-cases/page-build-errors/index.test.js
@@ -22,9 +22,12 @@ test.describe('page-build-errors', () => {
       assert.ok(Array.isArray(err.errors), 'Should have an array of errors')
 
       const pageResolveError = err.errors.find(err => err.message.includes('Error resolving page vars'))
+      const nestedPageResolveError = err.errors.find(err => err.page?.path === 'another-broken-page')
 
       assert.ok(pageResolveError, 'Should include a page resolve build error')
       assert.ok(pageResolveError.cause, 'Should include an error cause')
+      assert.ok(nestedPageResolveError, 'Should include a page resolve build error for the nested broken page')
+      assert.match(nestedPageResolveError.message, /page: "another-broken-page"/, 'Should include the page path in the error message')
     }
   })
 })

--- a/test-cases/test-build-helper/copyfolder/copied.txt
+++ b/test-cases/test-build-helper/copyfolder/copied.txt
@@ -1,0 +1,1 @@
+copied by testBuild

--- a/test-cases/test-build-helper/index.test.js
+++ b/test-cases/test-build-helper/index.test.js
@@ -1,0 +1,31 @@
+import { test } from 'node:test'
+import assert from 'node:assert'
+import { stat } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { testBuild } from '../../index.js'
+
+const __dirname = import.meta.dirname
+
+test.describe('testBuild', () => {
+  test('builds into a temporary directory and provides output helpers', async () => {
+    const src = join(__dirname, 'src')
+    const copy = join(__dirname, 'copyfolder')
+    const build = await testBuild(src, { copy: [copy] })
+
+    try {
+      assert.match(build.dest, /domstack-test-/, 'uses a domstack temp destination')
+      assert.ok(build.results, 'returns build results')
+
+      const html = await build.readOutput('index.html')
+      assert.match(html, /Test helper page/, 'reads generated page output')
+
+      const copied = await build.readOutput('copied.txt')
+      assert.strictEqual(copied, 'copied by testBuild\n', 'passes copy options through to DomStack')
+    } finally {
+      await build.cleanup()
+    }
+
+    await assert.rejects(stat(build.dest), 'cleanup removes the temporary destination')
+  })
+})

--- a/test-cases/test-build-helper/src/README.md
+++ b/test-cases/test-build-helper/src/README.md
@@ -1,0 +1,3 @@
+# Test helper page
+
+This page was built with `testBuild()`.


### PR DESCRIPTION
This PR completes the programmatic API testing improvements tracked in #234.

## Completed

- Resolves relative `copy` paths passed to the `DomStack` constructor to absolute paths from the current working directory, matching CLI `--copy` behavior.
- Stores resolved copy paths in `this.opts.copy` so downstream build and watch copy steps receive consistent absolute paths.
- Adds constructor copy-path tests for relative, absolute, and mixed copy paths.
- Documents programmatic `copy` path behavior in `README.md` and the `DomStackOpts` JSDoc.
- Improves worker page-build error reporting by restoring worker errors with page/template context in the error message, while preserving `cause`, stack, and attached metadata.
- Adds a regression assertion that page build errors include the affected page path.
- Adds a top-level `testBuild(src, opts)` helper for isolated programmatic test builds into temporary directories.
- Documents `testBuild()` usage and adds fixture coverage for generated output reading, copy-option pass-through, and cleanup.

## Validation

- `node --test --test-reporter spec test-cases/page-build-errors/index.test.js`
- `node --test --test-reporter spec test-cases/test-build-helper/index.test.js`
- `npm run test:tsc`
- `npm run test:neostandard`
- `npm run test:node-test`
- `npm run test:installed-check`

Closes #234