### PR TITLE
Migrate successful build fixtures to testBuild

### DIFF
--- a/test-cases/default-layout/index.test.js
+++ b/test-cases/default-layout/index.test.js
@@ -1,21 +1,19 @@
 import { test } from 'node:test'
 import assert from 'node:assert'
-import { DomStack } from '../../index.js'
+import { testBuild } from '../../index.js'
 import * as path from 'path'
-import { rm } from 'fs/promises'
 
 const __dirname = import.meta.dirname
 
 test.describe('default-layout', () => {
-  test('should build site with default layout', async () => {
+  test('should build site with default layout', async (t) => {
     const src = path.join(__dirname, './src')
-    const dest = path.join(__dirname, './public')
-    const siteUp = new DomStack(src, dest)
+    const build = await testBuild(src)
 
-    await rm(dest, { recursive: true, force: true })
+    t.after(async () => {
+      await build.cleanup()
+    })
 
-    await siteUp.build()
-
-    assert.ok(true, 'built with default layout')
+    assert.ok(build.results, 'built with default layout')
   })
 })

--- a/test-cases/drafts/index.test.js
+++ b/test-cases/drafts/index.test.js
@@ -1,22 +1,23 @@
 import { test } from 'node:test'
 import assert from 'node:assert'
-import { DomStack } from '../../index.js'
+import { testBuild } from '../../index.js'
 import * as path from 'path'
-import { rm, stat, readFile } from 'fs/promises'
+import { stat, readFile } from 'fs/promises'
 import * as cheerio from 'cheerio'
 import { allFiles } from 'async-folder-walker'
 
 const __dirname = import.meta.dirname
 
 test.describe('drafts', () => {
-  test('should build site with draft pages', async () => {
+  test('should build site with draft pages', async (t) => {
     const src = path.join(__dirname, './src')
-    const dest = path.join(__dirname, './public')
-    const siteUp = new DomStack(src, dest, { buildDrafts: true })
+    const build = await testBuild(src, { buildDrafts: true })
+    const { dest, results } = build
 
-    await rm(dest, { recursive: true, force: true })
+    t.after(async () => {
+      await build.cleanup()
+    })
 
-    const results = await siteUp.build()
     assert.ok(results, 'Domstack built site and returned build results')
 
     const pages = {

--- a/test-cases/general-features/index.test.js
+++ b/test-cases/general-features/index.test.js
@@ -1,8 +1,8 @@
 import { test } from 'node:test'
 import assert from 'node:assert'
-import { DomStack } from '../../index.js'
+import { testBuild } from '../../index.js'
 import * as path from 'path'
-import { rm, stat, readFile } from 'fs/promises'
+import { stat, readFile } from 'fs/promises'
 import * as cheerio from 'cheerio'
 import { allFiles } from 'async-folder-walker'
 
@@ -11,12 +11,13 @@ const __dirname = import.meta.dirname
 test.describe('general-features', () => {
   test('should build site with all features', async (t) => {
     const src = path.join(__dirname, './src')
-    const dest = path.join(__dirname, './public')
-    const siteUp = new DomStack(src, dest, { copy: [path.join(__dirname, './copyfolder')] })
+    const build = await testBuild(src, { copy: [path.join(__dirname, './copyfolder')] })
+    const { dest, results } = build
 
-    await rm(dest, { recursive: true, force: true })
+    t.after(async () => {
+      await build.cleanup()
+    })
 
-    const results = await siteUp.build()
     assert.ok(results, 'DomStack built site and returned build results')
 
     const globalAssets = {


### PR DESCRIPTION
Stacked on #251.

## Summary

Migrates successful one-shot build fixtures to use the new top-level `testBuild()` helper introduced in #251.

Updated tests:

- `test-cases/default-layout/index.test.js`
- `test-cases/drafts/index.test.js`
- `test-cases/general-features/index.test.js`

These tests now build into isolated temporary destinations and register `build.cleanup()` with `t.after()`.

Tests intentionally left on direct `DomStack` usage:

- error-path fixtures, because `testBuild()` throws before returning cleanup on failing builds
- `nested-dest`, because it specifically verifies building into a nested destination under the source tree
- watch tests, because they need direct `DomStack.watch()` control and stable temp source/dest paths
- constructor/type smoke tests, because they are not one-shot successful build fixtures

## Validation

- `node --test --test-reporter spec test-cases/default-layout/index.test.js test-cases/drafts/index.test.js test-cases/general-features/index.test.js`
- `npm run test:tsc`
- `npm run test:neostandard`
- `npm run test:node-test`