### PR TITLE
Await watch shutdown and clean up failed startup

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,6 +117,10 @@ export class DomStack {
   #watchDependencies = null
   /** @type {boolean} Failed builds may leave the previous routing state incomplete. */
   #pageBuildFailed = false
+  #starting = false
+  #acceptWatchEvents = false
+  /** @type {Promise<void> | null} */
+  #stopping = null
 
   // Serialized lock so concurrent chokidar events don't pile up
   /** @type {Promise<void>} */
@@ -176,8 +180,24 @@ export class DomStack {
   } = {
     serve: true,
   }) {
-    if (this.watching) throw new Error('Already watching.')
+    if (this.watching || this.#starting || this.#stopping) throw new Error('Already watching.')
+    this.#starting = true
+    try {
+      return await this.#startWatch({ serve, onInitialBuild })
+    } catch (error) {
+      try {
+        await this.#disposeWatchResources()
+      } catch (cleanupError) {
+        throw new AggregateError([error, cleanupError], 'Watch startup and cleanup failed')
+      }
+      throw error
+    } finally {
+      this.#starting = false
+    }
+  }
 
+  /** @param {{ serve: boolean, onInitialBuild: ((results: Results) => void | Promise<void>) | undefined }} params */
+  async #startWatch ({ serve, onInitialBuild }) {
     // ── Initial build (inline, not via builder()) ────────────────────────
     const siteData = await identifyPages(this.#src, this.opts)
 
@@ -239,10 +259,9 @@ export class DomStack {
     // ── Copy watchers & dev server ───────────────────────────────────────
     const copyDirs = getCopyDirs(this.opts.copy ?? [])
 
-    this.#cpxWatchers = [
-      cpxWatch(getCopyGlob(this.#src), this.#dest, { ignore: this.opts.ignore ?? [] }),
-      ...copyDirs.map(copyDir => cpxWatch(copyDir, this.#dest))
-    ]
+    this.#cpxWatchers = []
+    this.#cpxWatchers.push(cpxWatch(getCopyGlob(this.#src), this.#dest, { ignore: this.opts.ignore ?? [] }))
+    for (const copyDir of copyDirs) this.#cpxWatchers.push(cpxWatch(copyDir, this.#dest))
 
     const copyWatchersReady = this.#cpxWatchers.map(async w => {
       w.on('copy', (/** @type{{ srcPath: string, dstPath: string }} */e) => {
@@ -305,6 +324,7 @@ export class DomStack {
       })
     }
 
+    this.#acceptWatchEvents = true
     const enqueue = (/** @type {() => Promise<unknown>} */ fn) => {
       this.#enqueueBuild(fn)
     }
@@ -579,7 +599,9 @@ ${siteData.errors.map(err => ` ${err.message}`).join('\n')}`)
    * @param {() => Promise<unknown>} fn
    */
   #enqueueBuild (fn) {
+    if (!this.#acceptWatchEvents) return
     this.#buildLock = this.#buildLock.then(async () => {
+      if (!this.#acceptWatchEvents) return
       try {
         await fn()
       } catch (err) {
@@ -831,19 +853,38 @@ ${siteData.errors.map(err => ` ${err.message}`).join('\n')}`)
   }
 
   async stopWatching () {
+    if (this.#stopping) return this.#stopping
     if ((!this.watching || !this.#cpxWatchers)) throw new Error('Not watching')
-    if (this.#watcher) this.#watcher.close()
-    this.#cpxWatchers.forEach(w => {
-      w.close()
-    })
+    this.#stopping = this.#disposeWatchResources()
+    try {
+      await this.#stopping
+    } finally {
+      this.#stopping = null
+    }
+  }
+
+  async #disposeWatchResources () {
+    this.#acceptWatchEvents = false
+    const closures = [
+      () => this.#watcher?.close(),
+      ...(this.#cpxWatchers ?? []).map(w => () => w.close()),
+    ]
+    const results = await Promise.allSettled(closures.map(close => Promise.resolve().then(close)))
+
+    // Queued events are cancelled; a build already running may still replace the
+    // esbuild context, so wait before disposing the final context and server.
+    await this.#buildLock
+    results.push(...await Promise.allSettled([
+      Promise.resolve().then(() => this.#esbuildContext?.dispose()),
+      Promise.resolve().then(() => this.#syncServer?.exit()),
+    ]))
     this.#watcher = null
     this.#cpxWatchers = null
-    if (this.#esbuildContext) {
-      await this.#esbuildContext.dispose()
-      this.#esbuildContext = null
-    }
-    await this.#syncServer?.exit()
+    this.#esbuildContext = null
     this.#syncServer = null
+    this.#siteData = null
+    const errors = results.filter(result => result.status === 'rejected').map(result => result.reason)
+    if (errors.length > 0) throw new AggregateError(errors, 'Watch cleanup failed')
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -315,6 +315,9 @@ export class DomStack {
 
     await onInitialBuild?.(report)
 
+    // The callback may have stopped this watch session.
+    if (!this.watching || this.#stopping) return report
+
     if (serve) {
       this.#syncServer = await createServer({
         server: this.#dest,

--- a/index.js
+++ b/index.js
@@ -13,6 +13,11 @@
  * @import { WatchDependencyState } from './lib/build-pages/watch-dependencies.js'
  * @typedef {{ dispose: () => Promise<void> }} DisposableBuildContext
  * @typedef {{ pageFilePath: string, sourcePageFilePath?: string | undefined, pagesFilePath?: string | undefined, layoutNames: string[], outputs?: DomstackManifestRecord[] | undefined }} WatchedPageReport
+ * @typedef {object} WatchSession
+ * @property {'starting' | 'watching' | 'stopping'} state
+ * @property {AbortController} cancellation - Cancels event waits, not resource acquisition.
+ * @property {Promise<unknown>} startupWork - The current resource-acquiring startup phase; never the user callback.
+ * @property {Promise<void> | null} shutdown - Shared by explicit stops and startup failure cleanup.
  */
 import { once } from 'events'
 import assert from 'node:assert'
@@ -80,7 +85,7 @@ export class DomStack {
   /** @type {string} */ #dest = ''
   /** @type {Readonly<DomStackOpts>} */ opts
   /** @type {FSWatcher?} */ #watcher = null
-  /** @type {any[]?} */ #cpxWatchers = null
+  /** @type {ReturnType<typeof cpxWatch>[]} */ #cpxWatchers = []
   /** @type {BsInstance?} */ #syncServer = null
   /** @type {DisposableBuildContext?} */ #esbuildContext = null
   /** @type {SiteData?} */ #siteData = null
@@ -117,10 +122,12 @@ export class DomStack {
   #watchDependencies = null
   /** @type {boolean} Failed builds may leave the previous routing state incomplete. */
   #pageBuildFailed = false
-  #starting = false
-  #acceptWatchEvents = false
-  /** @type {Promise<void> | null} */
-  #stopping = null
+
+  // One session owns the resources above until shutdown finishes.
+  // Normal path: absent → starting → watching → stopping → absent.
+  // Startup failure or cancellation: starting → stopping → absent.
+  /** @type {WatchSession | null} */
+  #watchSession = null
 
   // Serialized lock so concurrent chokidar events don't pile up
   /** @type {Promise<void>} */
@@ -159,8 +166,9 @@ export class DomStack {
     }
   }
 
+  /** True from the start of watch() until shutdown completes, including startup. */
   get watching () {
-    return Boolean(this.#watcher)
+    return this.#watchSession !== null
   }
 
   build () {
@@ -169,6 +177,10 @@ export class DomStack {
 
   /**
    * Build and watch a domstack build
+   *
+   * Stopping during startup still returns the initial build report, but does not
+   * activate watch events. Await stopWatching() for completed resource cleanup.
+   *
    * @param  {object} [params]
    * @param  {boolean} params.serve
    * @param  {(results: Results) => void | Promise<void>} [params.onInitialBuild]
@@ -180,24 +192,78 @@ export class DomStack {
   } = {
     serve: true,
   }) {
-    if (this.watching || this.#starting || this.#stopping) throw new Error('Already watching.')
-    this.#starting = true
+    if (this.watching) throw new Error('Already watching.')
+    /** @type {WatchSession} */
+    const session = {
+      state: 'starting',
+      cancellation: new AbortController(),
+      startupWork: Promise.resolve(),
+      shutdown: null,
+    }
+    this.#watchSession = session
     try {
-      return await this.#startWatch({ serve, onInitialBuild })
+      return await this.#startWatch(session, { serve, onInitialBuild })
     } catch (error) {
       try {
-        await this.#disposeWatchResources()
+        await this.#stopWatchSession(session)
       } catch (cleanupError) {
+        // The callback may already be propagating this same shutdown failure.
+        if (error === cleanupError) throw error
         throw new AggregateError([error, cleanupError], 'Watch startup and cleanup failed')
       }
       throw error
-    } finally {
-      this.#starting = false
     }
   }
 
-  /** @param {{ serve: boolean, onInitialBuild: ((results: Results) => void | Promise<void>) | undefined }} params */
-  async #startWatch ({ serve, onInitialBuild }) {
+  /**
+   * Resource acquisition must finish before shutdown can release its results.
+   * Readiness waits, on the other hand, must be cancelled when watchers close.
+   * The user callback is outside the acquisition phases so it can await a stop.
+   *
+   * @param {WatchSession} session
+   * @param {{ serve: boolean, onInitialBuild: ((results: Results) => void | Promise<void>) | undefined }} params
+   */
+  async #startWatch (session, { serve, onInitialBuild }) {
+    const { signal } = session.cancellation
+    const preparation = this.#prepareWatch(signal)
+    session.startupWork = preparation
+    const { report, watcher, ready } = await preparation
+
+    await ready
+    if (signal.aborted) return report
+
+    await onInitialBuild?.(report)
+    if (signal.aborted) return report
+
+    if (serve) {
+      session.startupWork = this.#startWatchServer()
+      await session.startupWork
+      if (signal.aborted) return report
+    }
+
+    session.state = 'watching'
+    const enqueue = (/** @type {() => Promise<unknown>} */ fn) => {
+      this.#enqueueBuild(session, fn)
+    }
+
+    watcher.on('add', path => {
+      enqueue(() => this.#handleAddUnlink(path, 'added'))
+    })
+    watcher.on('change', path => {
+      assert(this.#src)
+      assert(this.#dest)
+      enqueue(() => this.#handleChange(path))
+    })
+    watcher.on('unlink', path => {
+      enqueue(() => this.#handleAddUnlink(path, 'removed'))
+    })
+    watcher.on('error', err => errorLogger(err, this.#logger))
+
+    return report
+  }
+
+  /** @param {AbortSignal} signal */
+  async #prepareWatch (signal) {
     // ── Initial build (inline, not via builder()) ────────────────────────
     const siteData = await identifyPages(this.#src, this.opts)
 
@@ -256,29 +322,14 @@ export class DomStack {
     // Build watch maps after initial build
     await this.#rebuildMaps(siteData)
 
-    // ── Copy watchers & dev server ───────────────────────────────────────
+    // Copy readiness is cancellable: cpx2 invalidates pending scans on close.
     const copyDirs = getCopyDirs(this.opts.copy ?? [])
-
-    this.#cpxWatchers = []
-    this.#cpxWatchers.push(cpxWatch(getCopyGlob(this.#src), this.#dest, { ignore: this.opts.ignore ?? [] }))
-    for (const copyDir of copyDirs) this.#cpxWatchers.push(cpxWatch(copyDir, this.#dest))
-
-    const copyWatchersReady = this.#cpxWatchers.map(async w => {
-      w.on('copy', (/** @type{{ srcPath: string, dstPath: string }} */e) => {
-        this.#logger.info(`Copy ${e.srcPath} to ${e.dstPath}`)
-      })
-
-      w.on('remove', (/** @type{{ path: string }} */e) => {
-        this.#logger.info(`Remove ${e.path}`)
-      })
-
-      w.on('watch-error', (/** @type{Error} */err) => {
-        this.#logger.error(`Copy error: ${err.message}`)
-      })
-
-      await once(w, 'watch-ready')
-      this.#logger.info('Copy watcher ready')
-    })
+    const copyStartup = await Promise.allSettled([
+      this.#startCopyWatcher(getCopyGlob(this.#src), signal, this.opts.ignore ?? []),
+      ...copyDirs.map(copyDir => this.#startCopyWatcher(copyDir, signal)),
+    ])
+    const copyErrors = copyStartup.filter(result => result.status === 'rejected').map(result => result.reason)
+    if (copyErrors.length) throw new AggregateError(copyErrors, 'Copy watch startup failed')
 
     // ── Chokidar watcher ─────────────────────────────────────────────────
     const ig = ignore().add(this.opts.ignore ?? [])
@@ -307,45 +358,59 @@ export class DomStack {
     })
 
     this.#watcher = watcher
+    // Attach the listener before returning; the watcher can become ready before
+    // the caller resumes. Cancellation settles this wait even without a ready event.
+    const ready = once(watcher, 'ready', { signal }).catch(error => {
+      if (!signal.aborted || error.name !== 'AbortError') throw error
+    })
 
-    await Promise.all([
-      ...copyWatchersReady,
-      once(watcher, 'ready'),
-    ])
+    return { report, watcher, ready }
+  }
 
-    await onInitialBuild?.(report)
+  /**
+   * @param {string} source
+   * @param {AbortSignal} signal
+   * @param {string[]} [ignores]
+   */
+  async #startCopyWatcher (source, signal, ignores = []) {
+    const watcher = cpxWatch(source, this.#dest, { ignore: ignores })
+    this.#cpxWatchers.push(watcher)
+    watcher.on('copy', (/** @type{{ srcPath: string, dstPath: string }} */e) => {
+      this.#logger.info(`Copy ${e.srcPath} to ${e.dstPath}`)
+    })
+    watcher.on('remove', (/** @type{{ path: string }} */e) => {
+      this.#logger.info(`Remove ${e.path}`)
+    })
+    watcher.on('watch-error', (/** @type{Error} */err) => {
+      this.#logger.error(`Copy error: ${err.message}`)
+    })
 
-    // The callback may have stopped this watch session.
-    if (!this.watching || this.#stopping) return report
-
-    if (serve) {
-      this.#syncServer = await createServer({
-        server: this.#dest,
-        files: basename(this.#dest),
-        ignore: ['**/domstack-esbuild-meta.json'],
-        logger: this.#logger.child({ component: 'sync', logPrefix: '[domstack-sync]' }),
-      })
+    // cpx2 reports startup failure as "watch-error", not EventEmitter's "error".
+    // A closed session may never emit readiness, so cancellation must also settle
+    // this wait. This does not drain file operations already started by cpx2.
+    const { promise, resolve, reject } = Promise.withResolvers()
+    const onAbort = () => resolve(undefined)
+    watcher.once('watch-ready', resolve)
+    watcher.once('watch-error', reject)
+    signal.addEventListener('abort', onAbort, { once: true })
+    try {
+      if (signal.aborted) return
+      await promise
+      if (!signal.aborted) this.#logger.info('Copy watcher ready')
+    } finally {
+      watcher.off('watch-ready', resolve)
+      watcher.off('watch-error', reject)
+      signal.removeEventListener('abort', onAbort)
     }
+  }
 
-    this.#acceptWatchEvents = true
-    const enqueue = (/** @type {() => Promise<unknown>} */ fn) => {
-      this.#enqueueBuild(fn)
-    }
-
-    watcher.on('add', path => {
-      enqueue(() => this.#handleAddUnlink(path, 'added'))
+  async #startWatchServer () {
+    this.#syncServer = await createServer({
+      server: this.#dest,
+      files: basename(this.#dest),
+      ignore: ['**/domstack-esbuild-meta.json'],
+      logger: this.#logger.child({ component: 'sync', logPrefix: '[domstack-sync]' }),
     })
-    watcher.on('change', path => {
-      assert(this.#src)
-      assert(this.#dest)
-      enqueue(() => this.#handleChange(path))
-    })
-    watcher.on('unlink', path => {
-      enqueue(() => this.#handleAddUnlink(path, 'removed'))
-    })
-    watcher.on('error', err => errorLogger(err, this.#logger))
-
-    return report
   }
 
   /**
@@ -599,12 +664,13 @@ ${siteData.errors.map(err => ` ${err.message}`).join('\n')}`)
   }
 
   /**
+   * @param {WatchSession} session
    * @param {() => Promise<unknown>} fn
    */
-  #enqueueBuild (fn) {
-    if (!this.#acceptWatchEvents) return
+  #enqueueBuild (session, fn) {
+    if (session.state !== 'watching') return
     this.#buildLock = this.#buildLock.then(async () => {
-      if (!this.#acceptWatchEvents) return
+      if (session.state !== 'watching') return
       try {
         await fn()
       } catch (err) {
@@ -855,37 +921,56 @@ ${siteData.errors.map(err => ` ${err.message}`).join('\n')}`)
     this.#logger.info(`"${changedBasename}" changed but did not match any rebuild rule, skipping.`)
   }
 
+  /**
+   * Cancel startup/event waits, drain owned work, and release the session.
+   * The user callback is not drained: it may itself be awaiting this stop.
+   * Concurrent stops share cleanup; a new watch may start once cleanup settles.
+   */
   async stopWatching () {
-    if (this.#stopping) return this.#stopping
-    if ((!this.watching || !this.#cpxWatchers)) throw new Error('Not watching')
-    this.#stopping = this.#disposeWatchResources()
-    try {
-      await this.#stopping
-    } finally {
-      this.#stopping = null
-    }
+    if (!this.#watchSession) throw new Error('Not watching')
+    return this.#stopWatchSession(this.#watchSession)
   }
 
-  async #disposeWatchResources () {
-    this.#acceptWatchEvents = false
+  /** @param {WatchSession} session */
+  #stopWatchSession (session) {
+    // Retain this promise on the session even after cleanup. An old callback may
+    // finish or throw after a new session starts; it must not clean up that session.
+    if (session.shutdown) return session.shutdown
+    session.state = 'stopping'
+    session.cancellation.abort()
+    session.shutdown = this.#disposeWatchResources(session)
+    return session.shutdown
+  }
+
+  /** @param {WatchSession} session */
+  async #disposeWatchResources (session) {
+    // 1. Drain resource acquisition. No new startup phase may begin after a stop.
+    //    watch() reports startup errors; shutdown still releases partial resources.
+    await session.startupWork.catch(() => {})
+
+    // 2. Stop filesystem producers. The session state already rejects new and
+    //    queued rebuilds, including callbacks retained by a previous watch session.
     const closures = [
       () => this.#watcher?.close(),
-      ...(this.#cpxWatchers ?? []).map(w => () => w.close()),
+      ...this.#cpxWatchers.map(w => () => w.close()),
     ]
     const results = await Promise.allSettled(closures.map(close => Promise.resolve().then(close)))
 
-    // Queued events are cancelled; a build already running may still replace the
-    // esbuild context, so wait before disposing the final context and server.
-    await this.#buildLock
+    // 3. Drain the active rebuild before releasing the esbuild context it may replace.
+    results.push(...await Promise.allSettled([this.#buildLock]))
+
+    // 4. Release the final contexts and server, even if another cleanup step failed.
     results.push(...await Promise.allSettled([
       Promise.resolve().then(() => this.#esbuildContext?.dispose()),
       Promise.resolve().then(() => this.#syncServer?.exit()),
     ]))
     this.#watcher = null
-    this.#cpxWatchers = null
+    this.#cpxWatchers = []
     this.#esbuildContext = null
     this.#syncServer = null
     this.#siteData = null
+    this.#buildLock = Promise.resolve()
+    this.#watchSession = null
     const errors = results.filter(result => result.status === 'rejected').map(result => result.reason)
     if (errors.length > 0) throw new AggregateError(errors, 'Watch cleanup failed')
   }

--- a/lib/build-esbuild/index.js
+++ b/lib/build-esbuild/index.js
@@ -525,40 +525,46 @@ export async function buildEsbuildWatch (src, dest, siteData, opts, watchOpts = 
 
   const initialResult = browserWatch.initialResult
 
-  await writeMetafile({ dest, result: initialResult, shouldWrite: opts?.metafile !== false })
-  const outputMap = applyBuildOutputMap({ dest, result: initialResult, siteData, src })
-
   /** @type {esbuild.BuildContext[]} */
   const contexts = [browserWatch.context]
+  try {
+    await writeMetafile({ dest, result: initialResult, shouldWrite: opts?.metafile !== false })
+    const outputMap = applyBuildOutputMap({ dest, result: initialResult, siteData, src })
 
-  if (siteData.serviceWorker) {
-    // Keep service-worker-only defines and no-policy watch cleanup behavior out of browser bundles.
-    const serviceWorkerBuildOpts = createServiceWorkerBuildOpts({
+    if (siteData.serviceWorker) {
+      // Keep service-worker-only defines and no-policy watch cleanup behavior out of browser bundles.
+      const serviceWorkerBuildOpts = createServiceWorkerBuildOpts({
+        buildOpts: extendedBuildOpts,
+        defines: {},
+        serviceWorker: siteData.serviceWorker,
+        src,
+      })
+      const serviceWorkerWatch = await createWatchBuild({
+        buildOpts: serviceWorkerBuildOpts,
+        dest,
+        label: 'Service worker',
+        shouldWriteMetafile: false,
+      })
+      contexts.push(serviceWorkerWatch.context)
+      applyBuildOutputMap({
+        dest,
+        result: serviceWorkerWatch.initialResult,
+        siteData,
+        src,
+      })
+    }
+
+    return {
+      context: createDisposableBuildContext(contexts),
+      outputMap,
+      buildResults: initialResult,
       buildOpts: extendedBuildOpts,
-      defines: {},
-      serviceWorker: siteData.serviceWorker,
-      src,
-    })
-    const serviceWorkerWatch = await createWatchBuild({
-      buildOpts: serviceWorkerBuildOpts,
-      dest,
-      label: 'Service worker',
-      shouldWriteMetafile: false,
-    })
-    applyBuildOutputMap({
-      dest,
-      result: serviceWorkerWatch.initialResult,
-      siteData,
-      src,
-    })
-    contexts.push(serviceWorkerWatch.context)
-  }
-
-  return {
-    context: createDisposableBuildContext(contexts),
-    outputMap,
-    buildResults: initialResult,
-    buildOpts: extendedBuildOpts,
+    }
+  } catch (error) {
+    const cleanup = await Promise.allSettled(contexts.map(context => context.dispose()))
+    const failures = cleanup.filter(result => result.status === 'rejected').map(result => result.reason)
+    if (failures.length) throw new AggregateError([error, ...failures], 'Esbuild watch startup and cleanup failed')
+    throw error
   }
 }
 
@@ -620,7 +626,9 @@ async function createWatchBuild ({ buildOpts, dest, label, onEnd, shouldWriteMet
 function createDisposableBuildContext (contexts) {
   return {
     async dispose () {
-      await Promise.all(contexts.map(context => context.dispose()))
+      const results = await Promise.allSettled(contexts.map(context => context.dispose()))
+      const errors = results.filter(result => result.status === 'rejected').map(result => result.reason)
+      if (errors.length) throw new AggregateError(errors, 'Esbuild watch cleanup failed')
     },
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "async-folder-walker": "^3.0.5",
     "chokidar": "^5.0.0",
     "clean-deep": "^3.4.0",
-    "cpx2": "^9.0.1",
+    "cpx2": "^9.0.2",
     "esbuild": "^0.28.1",
     "fragtml": "^0.0.9",
     "handlebars": "^4.7.8",

--- a/test-cases/watch-lifecycle/index.test.js
+++ b/test-cases/watch-lifecycle/index.test.js
@@ -4,14 +4,20 @@
  */
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtemp, mkdir, writeFile, readFile, rm, access } from 'node:fs/promises'
-import { join } from 'node:path'
-import { setTimeout as delay } from 'node:timers/promises'
+import { once } from 'node:events'
+import fs from 'node:fs'
+import fsPromises, { mkdtemp, mkdir, writeFile, readFile, rm, access } from 'node:fs/promises'
+import { Server } from 'node:net'
+import { join, resolve } from 'node:path'
+import { setImmediate, setTimeout as delay } from 'node:timers/promises'
 import chokidar from 'chokidar'
 import { DomStack } from '../../index.js'
 
-/** @param {TestContext} t */
-async function fixture (t) {
+/**
+ * @param {TestContext} t
+ * @param {(watcher: FSWatcher) => void} [onWatcher]
+ */
+async function fixture (t, onWatcher) {
   const root = await mkdtemp(join(import.meta.dirname, '.tmp-'))
   const src = join(root, 'src')
   const dest = join(root, 'public')
@@ -24,8 +30,13 @@ async function fixture (t) {
   const watch = chokidar.watch
   /** @param {Parameters<typeof watch>} args */
   const captureWatcher = (...args) => {
-    watcher = watch(...args)
-    return watcher
+    const result = watch(...args)
+    // The dev server also uses Chokidar; only capture DOMStack's source watcher.
+    if (args[0] === src) {
+      watcher = result
+      onWatcher?.(watcher)
+    }
+    return result
   }
   t.mock.method(chokidar, 'watch', captureWatcher)
   t.after(async () => {
@@ -42,6 +53,206 @@ async function fixture (t) {
     }
   }
 }
+
+test('shutdown during the initial build drains startup and permits a retry', { timeout: 15_000 }, async t => {
+  const site = await fixture(t)
+  let callbacks = 0
+  const starting = site.dom.watch({
+    serve: true,
+    onInitialBuild () { callbacks++ },
+  })
+  assert.equal(site.dom.watching, true)
+  const shutdown = site.dom.stopWatching()
+  const repeatedShutdown = site.dom.stopWatching()
+  await assert.rejects(site.dom.watch({ serve: false }), /Already watching/)
+  await Promise.all([starting, shutdown, repeatedShutdown])
+  assert.equal(callbacks, 0)
+  assert.equal(site.dom.watching, false)
+  assert.equal(site.watcher().closed, true)
+  assert.equal(site.watcher().listenerCount('ready'), 0)
+  await site.dom.watch({ serve: false })
+  await site.dom.stopWatching()
+})
+
+test('shutdown cancels watcher readiness without waiting for a ready event', { timeout: 15_000 }, async t => {
+  const reachedReady = Promise.withResolvers()
+  let holdReady = true
+  const site = await fixture(t, watcher => {
+    if (!holdReady) return
+    const emit = watcher.emit.bind(watcher)
+    /** @param {Parameters<typeof emit>} args */
+    const emitWithoutReady = (...args) => {
+      if (args[0] === 'ready') {
+        reachedReady.resolve(undefined)
+        return false
+      }
+      return emit(...args)
+    }
+    t.mock.method(watcher, 'emit', emitWithoutReady)
+  })
+  let callbacks = 0
+  const starting = site.dom.watch({
+    serve: false,
+    onInitialBuild () { callbacks++ },
+  })
+  await reachedReady.promise
+  await Promise.all([site.dom.stopWatching(), starting])
+  assert.equal(callbacks, 0)
+  assert.equal(site.dom.watching, false)
+  assert.equal(site.watcher().closed, true)
+  assert.equal(site.watcher().listenerCount('ready'), 0)
+  assert.equal(site.watcher().listenerCount('change'), 0)
+  holdReady = false
+  await site.dom.watch({ serve: false })
+  await site.dom.stopWatching()
+})
+
+test('shutdown cancels a pending copy scan without acquiring late native watchers', { timeout: 15_000 }, async t => {
+  const site = await fixture(t)
+  const copyDir = join(site.src, '..', 'copy')
+  await mkdir(copyDir)
+  await writeFile(join(copyDir, 'asset.txt'), 'copied')
+  const dom = new DomStack(site.src, site.dest, { copy: [copyDir] })
+  t.after(async () => { if (dom.watching) await dom.stopWatching() })
+  const entered = Promise.withResolvers()
+  const release = Promise.withResolvers()
+  const resumed = Promise.withResolvers()
+  const lstat = fsPromises.lstat
+  let rootChecks = 0
+  /** @param {Parameters<typeof lstat>} args */
+  const lstatWithGate = async (...args) => {
+    // Hold the symlink check after cpx2's first session guard: the 9.0.1 leak window.
+    if (resolve(String(args[0])) === copyDir && ++rootChecks === 2) {
+      entered.resolve(undefined)
+      await release.promise
+      try {
+        return await Reflect.apply(lstat, fsPromises, args)
+      } finally {
+        resumed.resolve(undefined)
+      }
+    }
+    return Reflect.apply(lstat, fsPromises, args)
+  }
+  t.mock.method(fsPromises, 'lstat', lstatWithGate)
+  const watch = fs.watch
+  /** @type {ReturnType<typeof watch>[]} */
+  const handles = []
+  /** @type {Promise<unknown>[]} */
+  const closures = []
+  /** @param {Parameters<typeof watch>} args */
+  const trackNativeWatcher = (...args) => {
+    const watcher = Reflect.apply(watch, fs, args)
+    if (resolve(String(args[0])) === copyDir) {
+      handles.push(watcher)
+      closures.push(once(watcher, 'close'))
+    }
+    return watcher
+  }
+  t.mock.method(fs, 'watch', trackNativeWatcher)
+  const starting = dom.watch({ serve: false })
+  try {
+    await entered.promise
+    // Shutdown must finish while the scan is still held, not wait for watch-ready.
+    await Promise.all([starting, dom.stopWatching()])
+    assert.equal(dom.watching, false)
+    release.resolve(undefined)
+    await resumed.promise
+    await setImmediate()
+    assert.equal(handles.length, 0)
+    await assert.rejects(access(join(site.dest, 'asset.txt')), { code: 'ENOENT' })
+
+    await dom.watch({ serve: false })
+    assert.equal(await readFile(join(site.dest, 'asset.txt'), 'utf8'), 'copied')
+    assert.ok(handles.length > 0)
+    await dom.stopWatching()
+    await Promise.all(closures)
+    assert.equal(dom.watching, false)
+  } finally {
+    release.resolve(undefined)
+    await starting
+    await resumed.promise
+    await setImmediate()
+    // Also close any leaked handles when checking against a regressed dependency.
+    for (const handle of handles) handle.close()
+    await Promise.all(closures)
+  }
+})
+
+test('copy watcher startup errors settle watch and permit a retry', { timeout: 15_000 }, async t => {
+  const site = await fixture(t)
+  const copyDir = join(site.src, '..', 'missing-copy')
+  const dom = new DomStack(site.src, site.dest, { copy: [copyDir] })
+  t.after(async () => { if (dom.watching) await dom.stopWatching() })
+  await assert.rejects(dom.watch({ serve: false }), error => {
+    assert.ok(error instanceof AggregateError)
+    assert.equal(error.message, 'Copy watch startup failed')
+    assert.equal(error.errors[0].code, 'ENOENT')
+    return true
+  })
+  assert.equal(dom.watching, false)
+  await mkdir(copyDir)
+  await writeFile(join(copyDir, 'asset.txt'), 'copied')
+  await dom.watch({ serve: false })
+  assert.equal(await readFile(join(site.dest, 'asset.txt'), 'utf8'), 'copied')
+  await dom.stopWatching()
+})
+
+test('shutdown drains late server creation and closes its listening ports', { timeout: 15_000 }, async t => {
+  const site = await fixture(t)
+  const entered = Promise.withResolvers()
+  const release = Promise.withResolvers()
+  const listen = Server.prototype.listen
+  /** @type {Set<Server>} */
+  const servers = new Set()
+  let holdListen = true
+  /**
+   * @this {Server}
+   * @param {Parameters<typeof listen>} args
+   */
+  function listenWithGate (...args) {
+    servers.add(this)
+    if (holdListen) {
+      holdListen = false
+      entered.resolve(undefined)
+      // Hold the real server factory at its first port probe, not a replacement
+      // server implementation. After release, all normal server resources start.
+      release.promise.then(() => Reflect.apply(listen, this, args))
+      return this
+    }
+    return Reflect.apply(listen, this, args)
+  }
+  t.mock.method(Server.prototype, 'listen', listenWithGate)
+  const starting = site.dom.watch({ serve: true })
+  try {
+    await entered.promise
+    let stopped = false
+    const shutdown = site.dom.stopWatching().then(() => { stopped = true })
+    await delay(20)
+    assert.equal(stopped, false)
+    await assert.rejects(site.dom.watch({ serve: false }), /Already watching/)
+    release.resolve(undefined)
+    await Promise.all([starting, shutdown])
+    assert.ok(servers.size > 0)
+    assert.ok([...servers].every(server => !server.listening))
+    assert.equal(site.dom.watching, false)
+    assert.equal(site.watcher().listenerCount('change'), 0)
+
+    // A normal served session must still start, serve the page, and stop afterward.
+    await site.dom.watch({ serve: true })
+    const pages = await Promise.all([...servers].filter(server => server.listening).map(async server => {
+      const address = server.address()
+      assert.ok(address && typeof address !== 'string')
+      const response = await fetch(`http://127.0.0.1:${address.port}/`)
+      return response.text()
+    }))
+    assert.ok(pages.some(page => page.includes('initial')))
+    await site.dom.stopWatching()
+    assert.ok([...servers].every(server => !server.listening))
+  } finally {
+    release.resolve(undefined)
+    await starting
+  }
+})
 
 test('shutdown awaits asynchronous watcher closure and supports repeated cycles', async t => {
   const site = await fixture(t)
@@ -83,7 +294,7 @@ test('failed startup closes acquired watchers and permits a retry', async t => {
 test('stopping in the initial-build callback does not resume watch startup', async t => {
   const site = await fixture(t)
   await site.dom.watch({
-    serve: false,
+    serve: true,
     onInitialBuild: () => site.dom.stopWatching(),
   })
   assert.equal(site.dom.watching, false)
@@ -91,6 +302,36 @@ test('stopping in the initial-build callback does not resume watch startup', asy
   assert.equal(site.watcher().listenerCount('change'), 0)
   await site.dom.watch({ serve: false })
   await site.dom.stopWatching()
+})
+
+test('a late callback failure cannot clean up a replacement session', { timeout: 15_000 }, async t => {
+  const site = await fixture(t)
+  const entered = Promise.withResolvers()
+  const release = Promise.withResolvers()
+  const starting = site.dom.watch({
+    serve: true,
+    async onInitialBuild () {
+      entered.resolve(undefined)
+      await release.promise
+      throw new Error('old callback failed')
+    },
+  })
+  const failed = assert.rejects(starting, /old callback failed/)
+  try {
+    await entered.promise
+    await site.dom.stopWatching()
+    await site.dom.watch({ serve: false })
+    const replacement = site.watcher()
+    release.resolve(undefined)
+    await failed
+    assert.equal(site.dom.watching, true)
+    assert.equal(replacement.closed, false)
+    assert.equal(replacement.listenerCount('change'), 1)
+    await site.dom.stopWatching()
+  } finally {
+    release.resolve(undefined)
+    await failed
+  }
 })
 
 test('cleanup reports close failures after releasing remaining resources', async t => {
@@ -107,6 +348,69 @@ test('cleanup reports close failures after releasing remaining resources', async
     assert.match(error.errors[0].message, /close failed/)
     return true
   })
+  assert.equal(site.dom.watching, false)
+  await site.dom.watch({ serve: false })
+  await site.dom.stopWatching()
+})
+
+test('readiness failure preserves both startup and cleanup errors', { timeout: 15_000 }, async t => {
+  const startupError = new Error('watcher failed before ready')
+  const cleanupError = new Error('watcher close failed')
+  let failReady = true
+  let closes = 0
+  const site = await fixture(t, watcher => {
+    if (!failReady) return
+    const emit = watcher.emit.bind(watcher)
+    /** @param {Parameters<typeof emit>} args */
+    const emitErrorInsteadOfReady = (...args) => {
+      if (args[0] === 'ready') return emit('error', startupError)
+      return emit(...args)
+    }
+    t.mock.method(watcher, 'emit', emitErrorInsteadOfReady)
+    const close = watcher.close.bind(watcher)
+    t.mock.method(watcher, 'close', async () => {
+      closes++
+      await close()
+      throw cleanupError
+    })
+  })
+  await assert.rejects(site.dom.watch({ serve: false }), error => {
+    assert.ok(error instanceof AggregateError)
+    assert.equal(error.errors[0], startupError)
+    assert.ok(error.errors[1] instanceof AggregateError)
+    assert.deepEqual(error.errors[1].errors, [cleanupError])
+    return true
+  })
+  assert.equal(closes, 1)
+  assert.equal(site.dom.watching, false)
+  assert.equal(site.watcher().closed, true)
+  failReady = false
+  await site.dom.watch({ serve: false })
+  await site.dom.stopWatching()
+})
+
+test('a callback-requested stop reports its cleanup failure only once', { timeout: 15_000 }, async t => {
+  const site = await fixture(t)
+  const cleanupError = new Error('watcher close failed')
+  let closes = 0
+  await assert.rejects(site.dom.watch({
+    serve: true,
+    onInitialBuild () {
+      const watcher = site.watcher()
+      const close = watcher.close.bind(watcher)
+      t.mock.method(watcher, 'close', async () => {
+        closes++
+        await close()
+        throw cleanupError
+      })
+      return site.dom.stopWatching()
+    },
+  }), error => {
+    assert.ok(error instanceof AggregateError)
+    assert.deepEqual(error.errors, [cleanupError])
+    return true
+  })
+  assert.equal(closes, 1)
   assert.equal(site.dom.watching, false)
   await site.dom.watch({ serve: false })
   await site.dom.stopWatching()

--- a/test-cases/watch-lifecycle/index.test.js
+++ b/test-cases/watch-lifecycle/index.test.js
@@ -1,0 +1,155 @@
+/**
+ * @import { TestContext } from 'node:test'
+ * @import { FSWatcher } from 'chokidar'
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, writeFile, readFile, rm, access } from 'node:fs/promises'
+import { join } from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+import chokidar from 'chokidar'
+import { DomStack } from '../../index.js'
+
+/** @param {TestContext} t */
+async function fixture (t) {
+  const root = await mkdtemp(join(import.meta.dirname, '.tmp-'))
+  const src = join(root, 'src')
+  const dest = join(root, 'public')
+  await mkdir(src)
+  await writeFile(join(src, 'root.layout.js'), 'export default ({ children }) => children\n')
+  await writeFile(join(src, 'page.js'), "export default () => 'initial'\n")
+  const dom = new DomStack(src, dest)
+  /** @type {FSWatcher | undefined} */
+  let watcher
+  const watch = chokidar.watch
+  /** @param {Parameters<typeof watch>} args */
+  const captureWatcher = (...args) => {
+    watcher = watch(...args)
+    return watcher
+  }
+  t.mock.method(chokidar, 'watch', captureWatcher)
+  t.after(async () => {
+    if (dom.watching) await dom.stopWatching()
+    await rm(root, { recursive: true, force: true })
+  })
+  return {
+    dom,
+    src,
+    dest,
+    watcher: () => {
+      assert.ok(watcher)
+      return watcher
+    }
+  }
+}
+
+test('shutdown awaits asynchronous watcher closure and supports repeated cycles', async t => {
+  const site = await fixture(t)
+  await site.dom.watch({ serve: false })
+  const watcher = site.watcher()
+  const close = watcher.close.bind(watcher)
+  const gate = Promise.withResolvers()
+  t.mock.method(watcher, 'close', async () => {
+    await close()
+    await gate.promise
+  })
+  let stopped = false
+  const shutdown = site.dom.stopWatching().then(() => { stopped = true })
+  await delay(20)
+  assert.equal(stopped, false)
+  await assert.rejects(site.dom.watch({ serve: false }), /Already watching/)
+  gate.resolve(undefined)
+  await shutdown
+  assert.equal(site.dom.watching, false)
+  for (let i = 0; i < 3; i++) {
+    await site.dom.watch({ serve: false })
+    await site.dom.stopWatching()
+    assert.equal(site.watcher().closed, true)
+  }
+})
+
+test('failed startup closes acquired watchers and permits a retry', async t => {
+  const site = await fixture(t)
+  await assert.rejects(site.dom.watch({
+    serve: false,
+    onInitialBuild () { throw new Error('callback failed') },
+  }), /callback failed/)
+  assert.equal(site.watcher().closed, true)
+  assert.equal(site.dom.watching, false)
+  await site.dom.watch({ serve: false })
+  await site.dom.stopWatching()
+})
+
+test('cleanup reports close failures after releasing remaining resources', async t => {
+  const site = await fixture(t)
+  await site.dom.watch({ serve: false })
+  const watcher = site.watcher()
+  const close = watcher.close.bind(watcher)
+  t.mock.method(watcher, 'close', async () => {
+    await close()
+    throw new Error('close failed')
+  })
+  await assert.rejects(site.dom.stopWatching(), error => {
+    assert.ok(error instanceof AggregateError)
+    assert.match(error.errors[0].message, /close failed/)
+    return true
+  })
+  assert.equal(site.dom.watching, false)
+  await site.dom.watch({ serve: false })
+  await site.dom.stopWatching()
+})
+
+test('service-worker startup failure disposes both esbuild contexts', async t => {
+  const site = await fixture(t)
+  await writeFile(join(site.src, 'client.js'), 'console.log("client")\n')
+  await writeFile(join(site.src, 'service-worker.js'), 'export default (\n')
+  await writeFile(join(site.src, 'esbuild.settings.js'), `import { appendFileSync } from 'node:fs'
+export default options => ({ ...options, plugins: [{
+  name: 'observe-disposal',
+  setup (build) {
+    build.onDispose(() => appendFileSync(import.meta.dirname + '/.disposed', 'disposed\\n'))
+  },
+}] })
+`)
+  await assert.rejects(site.dom.watch({ serve: false }), /Error starting esbuild watch context/)
+  for (let i = 0; i < 100; i++) {
+    const contents = await readFile(join(site.src, '.disposed'), 'utf8').catch(() => '')
+    if (contents === 'disposed\ndisposed\n') break
+    await delay(10)
+  }
+  assert.equal(await readFile(join(site.src, '.disposed'), 'utf8'), 'disposed\ndisposed\n')
+  assert.equal(site.dom.watching, false)
+})
+
+test('shutdown drains an active page build and cancels queued events', { timeout: 15_000 }, async t => {
+  const site = await fixture(t)
+  await writeFile(join(site.src, 'page.js'), `import { existsSync, writeFileSync, appendFileSync } from 'node:fs'
+import { setTimeout } from 'node:timers/promises'
+export default async () => {
+  const root = import.meta.dirname
+  if (existsSync(root + '/.block')) {
+    appendFileSync(root + '/.runs', 'run\\n')
+    writeFileSync(root + '/.started', '')
+    while (!existsSync(root + '/.release')) await setTimeout(10)
+  }
+  return 'rendered'
+}
+`)
+  await site.dom.watch({ serve: false })
+  await writeFile(join(site.src, '.block'), '')
+  site.watcher().emit('change', join(site.src, 'page.js'))
+  for (let i = 0; i < 500; i++) {
+    if (await access(join(site.src, '.started')).then(() => true, () => false)) break
+    await delay(10)
+  }
+  await access(join(site.src, '.started'))
+  site.watcher().emit('change', join(site.src, 'page.js'))
+  let stopped = false
+  const shutdown = site.dom.stopWatching().then(() => { stopped = true })
+  await delay(20)
+  assert.equal(stopped, false)
+  await writeFile(join(site.src, '.release'), '')
+  await shutdown
+  assert.equal(await readFile(join(site.src, '.runs'), 'utf8'), 'run\n')
+  assert.equal(await readFile(join(site.dest, 'index.html'), 'utf8'), 'rendered')
+})

--- a/test-cases/watch-lifecycle/index.test.js
+++ b/test-cases/watch-lifecycle/index.test.js
@@ -80,6 +80,19 @@ test('failed startup closes acquired watchers and permits a retry', async t => {
   await site.dom.stopWatching()
 })
 
+test('stopping in the initial-build callback does not resume watch startup', async t => {
+  const site = await fixture(t)
+  await site.dom.watch({
+    serve: false,
+    onInitialBuild: () => site.dom.stopWatching(),
+  })
+  assert.equal(site.dom.watching, false)
+  assert.equal(site.watcher().closed, true)
+  assert.equal(site.watcher().listenerCount('change'), 0)
+  await site.dom.watch({ serve: false })
+  await site.dom.stopWatching()
+})
+
 test('cleanup reports close failures after releasing remaining resources', async t => {
   const site = await fixture(t)
   await site.dom.watch({ serve: false })

--- a/test-cases/watch/index.test.js
+++ b/test-cases/watch/index.test.js
@@ -318,10 +318,6 @@ test.describe('watch', () => {
   test('progressive rebuilds', { timeout: 60_000 }, async (t) => {
     const { src, dest, tmp } = await setupTempSite()
 
-    t.after(async () => {
-      await rm(tmp, { recursive: true, force: true })
-    })
-
     const mockLog = mock.method(console, 'log')
     const loggerLogs = /** @type {string[]} */ ([])
     const logger = createTestLogger(loggerLogs)
@@ -330,6 +326,7 @@ test.describe('watch', () => {
     t.after(async () => {
       if (domStack.watching) await domStack.stopWatching()
       mockLog.mock.restore()
+      await rm(tmp, { recursive: true, force: true })
     })
 
     // ── Initial build ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #295. This is the base of an independent watch-maintenance stack targeting `master`.

- Await Chokidar closure and stop accepting new or queued rebuilds before shutdown drains the active build.
- Dispose every acquired copy watcher, esbuild context, and development server even if another cleanup step fails.
- Clean up partial watch startup, including browser/service-worker esbuild startup failures.
- Stop watchers before removing test fixtures.

## Validation

- Full Node suite, TypeScript, ESLint, installed dependency checks, and Playwright passed after rebasing onto the merged layout/subscription work.
- Filesystem-watch tests used Chokidar polling because native watchers are exhausted on this host.
- Lifecycle regressions cover awaited closure, repeated cycles, startup and cleanup failures, partial esbuild startup, active/queued rebuild shutdown, and stopping from the initial-build callback.

## Merge order

This PR targets `master` directly. #305 and #306 follow this branch.